### PR TITLE
(DOCS-9244): Added read preference mongo-uri options.

### DIFF
--- a/source/includes/options-mongosqld.yaml
+++ b/source/includes/options-mongosqld.yaml
@@ -70,9 +70,9 @@ description: |
   option.
 
   The {{role}} option also supports the :urioption:`readPreference` and
-  :urioption:`readPreferenceTags` connection string URI Options. To
-  learn how these connection string URI options work, see
-  :ref:`Read Preference Options <connections-read-preference>`.
+  :urioption:`readPreferenceTags` {{program}}  connection string URI
+  options. To learn more about connection string URI options,
+  see :ref:`Read Preference options <connections-read-preference>`.
 
 optional: true
 default: mongodb://localhost:27017

--- a/source/includes/options-mongosqld.yaml
+++ b/source/includes/options-mongosqld.yaml
@@ -68,6 +68,12 @@ description: |
 
   To enable TLS/SSL in this connection, use the :option:`--mongo-ssl`
   option.
+
+  The {{role}} option also supports the :urioption:`readPreference` and
+  :urioption:`readPreferenceTags` connection string URI Options. To
+  learn how these connection string URI options work, see
+  :ref:`Read Preference Options <connections-read-preference>`.
+
 optional: true
 default: mongodb://localhost:27017
 ---


### PR DESCRIPTION
Added information that BI Connector supports the readPreference ande readPreferenceTags options in the --mongo-uri option. [Staged](https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/anthonysansone/DOCS-9244/reference/mongosqld.html#cmdoption--mongo-uri)