### PR TITLE
(DOCS-10434): Removed mention of Kerberos throughout documentation.

### DIFF
--- a/source/includes/options-mongodrdl.yaml
+++ b/source/includes/options-mongodrdl.yaml
@@ -159,26 +159,6 @@ description: |
 optional: true
 ---
 program: mongodrdl
-name: gssapiServiceName
-directive: option
-args: <service-name>
-default: mongodb
-description: |
-  Specifies the service name to use when authenticating using
-  GSSAPI/Kerberos.
-optional: true
----
-program: mongodrdl
-name: gssapiHostName
-directive: option
-args: <host-name>
-default: remote server's hostname
-description: |
-  Specifies the hostname to use when authenticating using
-  GSSAPI/Kerberos.
-optional: true
----
-program: mongodrdl
 name: ssl
 directive: option
 inherit:

--- a/source/includes/options-shared.yaml
+++ b/source/includes/options-shared.yaml
@@ -128,12 +128,6 @@ description: |
 
        - MongoDB TLS/SSL certificate authentication.
 
-     * - :ref:`GSSAPI <security-auth-kerberos>` (Kerberos)
-
-       - External authentication using Kerberos. This mechanism is
-         available only in `MongoDB Enterprise
-         <http://www.mongodb.com/products/mongodb-enterprise?jmp=docs>`_.
-
      * - :ref:`PLAIN <security-auth-ldap>` (LDAP SASL)
 
        - External authentication using LDAP. You can also use ``PLAIN``

--- a/source/reference/mongodrdl.txt
+++ b/source/reference/mongodrdl.txt
@@ -7,7 +7,7 @@
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 1
+   :depth: 2
    :class: singlecol
 
 .. only:: html
@@ -67,12 +67,12 @@ Core Options
 
 .. include:: /includes/option/option-mongodrdl-preJoined.rst
 
-Kerberos Options
-~~~~~~~~~~~~~~~~
+.. Kerberos Options
+.. ~~~~~~~~~~~~~~~~
 
-.. include:: /includes/option/option-mongodrdl-gssapiServiceName.rst
+.. .. include:: /includes/option/option-mongodrdl-gssapiServiceName.rst
 
-.. include:: /includes/option/option-mongodrdl-gssapiHostName.rst
+.. .. include:: /includes/option/option-mongodrdl-gssapiHostName.rst
 
 TLS/SSL Options
 ~~~~~~~~~~~~~~~

--- a/source/tutorial/connecting.txt
+++ b/source/tutorial/connecting.txt
@@ -58,13 +58,16 @@ username as URI-style query parameters:
        The ``PLAIN`` (LDAP) mechanism requires MongoDB Enterprise, and
        requires that :urioption:`source` be ``$external``.
 
-For example, to authenticate as the user ``grace`` with authentication
-mechanism ``PLAIN`` and using an external source, you would use the
-following username:
+       .. note:: Kerberos is not supported.
 
-.. code::
+.. example::
+   To authenticate as the user ``grace`` with authentication
+   mechanism ``PLAIN`` and using an external source, you would use the
+   following username:
 
-   grace?mechanism=PLAIN&source=$external
+   .. code::
+
+      grace?mechanism=PLAIN&source=$external
 
 .. _connect-with-mysql:
 
@@ -79,6 +82,7 @@ Connect from MySQL without Authentication or TLS/SSL
 To connect to a :program:`mongosqld` instance listening on the MySQL
 default port ``3307``, run the following command:
 
+.. cssclass:: copyable-code
 .. code-block:: sh
 
    mysql --protocol tcp --port 3307
@@ -98,6 +102,7 @@ To connect to a :program:`mongosqld` instance listening on port ``3307``,
 as user ``grace`` using authentication mechanism ``PLAIN``, and using
 specific TLS/SSL CA and x.509 certificates, run the following command:
 
+.. cssclass:: copyable-code
 .. code-block:: sh
 
    mysql --enable-cleartext-plugin --protocol tcp --port 3307 \


### PR DESCRIPTION
@rkumar-mongo : This removes Kerberos from the BI Connector documentation. [Staged](https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/anthonysansone/DOCS-10434/tutorial/connecting.html)