### PR TITLE
DOCSP-855 - Added note about binding to multiple IP addresses.

### DIFF
--- a/source/reference/mongosqld.txt
+++ b/source/reference/mongosqld.txt
@@ -204,6 +204,13 @@ Network Options
    * - .. setting:: net.bindIp
      - string
      - The hostname component of :option:`--addr`
+       
+       .. versionchanged:: 2.2
+          To bind to multiple IP addresses, enter a list of comma separated values.
+
+       .. example::
+
+          "72.198.41.200,72.198.41.201,72.198.41.202"
 
    * - .. setting:: net.port
      - integer


### PR DESCRIPTION
Staged: https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/jdestefano/DOCSP-855/reference/mongosqld.html#net.bindIp