### PR TITLE
(DOCSP-970): Updated 2.2 Tableau connectivity.

### DIFF
--- a/source/includes/facts/tableau-restart.rst
+++ b/source/includes/facts/tableau-restart.rst
@@ -1,0 +1,3 @@
+.. important:: 
+  Any time you change a ``.tdc`` file, you must restart the Tableau
+  Desktop application for those changes to take effect.

--- a/source/includes/list-tables/tableau-default-tdc-locations.rst
+++ b/source/includes/list-tables/tableau-default-tdc-locations.rst
@@ -1,0 +1,11 @@
+.. list-table::
+   :widths: 20 80
+   :stub-columns: 1
+   :header-rows: 1
+
+   * - Platform
+     - Default TDC Save Path
+   * - macOS
+     - ``/Users/{name}/Documents/My Tableau Repository/Datasources``
+   * - Windows
+     - ``C:\Users\{username}\Documents\My Tableau Repository\Datasources``

--- a/source/includes/steps-connect-tableau-authentication-tdc.yaml
+++ b/source/includes/steps-connect-tableau-authentication-tdc.yaml
@@ -1,51 +1,42 @@
-title: Configure Tableau Datasource Connection.
+title: Create a Tableau Datasource Connection file.
 ref: configure-tdc
+stepnum: 1
 level: 4
-pre: |
-  The TDC file is a convenient way to enable the cleartext plugin and
-  specify all of :program:`mongosqld`'s TLS/SSL certificates and keys.
+content: |
 
-  To create a TDC file that can connect to the |bi| with authentication
-  over TLS/SSL, modify the following TDC file template. Substitute
-  ``SSLKEY``, ``SSLCERT``, and ``SSLCA`` appropriately:
+  The TDC file is a convenient way to enable the cleartext plugin
+  and specify all of :program:`mongosqld`'s TLS/SSL certificates
+  and keys.
 
-  .. code-block:: xml
+  To create a TDC file that can connect to the |bi| with
+  authentication over TLS/SSL, modify the following ``.tdc`` file
+  template. Substitute ``SSLKEY``, ``SSLCERT``, and ``SSLCA``
+  appropriately:
 
-     <?xml version='1.0' encoding='utf-8' ?>
-     <connection-customization class='mysql' version='7.7' enabled='true'>
-         <vendor name='mysql' />
-         <driver name='mysql' />
-         <customizations>
-           <customization
-             name='odbc-connect-string-extras'
-             value='SSLKEY={C:\path_to_key\mysql.key};SSLCERT={C:\path_to_cert\mysql.crt};SSLCA={C:\path_to_CAcert\ca.crt};ENABLE_CLEARTEXT_PLUGIN=1;SSL_ENFORCE=1' />
-           </customizations>
-     </connection-customization>
+  .. class:: copyable-code
+  .. literalinclude:: /includes/tdc/mongodb-ssl.tdc
+     :language: xml
+     :emphasize-lines: 6-12
+     :linenos:
 
-  Save this XML as a ``.tdc`` file in the ``Datasources`` directory of
-  your Tableau Repository. On Windows this is typically
-  ``C:\Users\<username>\Documents\My Tableau Repository\Datasources``. On
-  OS X, this is ``~/Documents/My Tableau Repository/Datasources``.
+  Save this file as ``mongodb.tdc`` in the :guilabel:`My Tableau
+  Repository` for your platform:
 
-  .. important::
-     You must restart Tableau to apply the TDC.
+  .. include:: /includes/list-tables/tableau-default-tdc-locations.rst
 
-     Tableau will apply the TLS/SSL, certificate, and cleartext plugin
-     settings in the TDC file to **every** connection matching the named
-     database vendor and driver.
+  .. include:: /includes/facts/tableau-restart.rst
+
+  Tableau applies the TLS/SSL, certificate, and cleartext plugin
+  settings in the ``.tdc`` file to *every* connection matching
+  the named database vendor and driver.
+
 ---
 title: Connect using Tableau.
 ref: connect
 level: 4
-pre: |
-   Click on the :guilabel:`MySQL` named connection in Tableau's left
-   hand column. Enter the host and port on which :program:`mongosqld` is
-   listening, along with the username and password with which to
-   authenticate. Click :guilabel:`Sign In` to connect.
+stepnum: 2
+source:
+  file: steps-connect-tableau-mongosql-plugin.yaml
+  ref: connect-tableau
 
-   By default, :program:`mongosqld` binds to port ``3307``.
-
-   .. figure:: /images/bi-connector/tableau-auth.png
-      :alt: Screenshot of Tableau with the MySQL connection panel open
-      :figwidth: 700px
 ...

--- a/source/includes/steps-connect-tableau-mongosql-plugin.yaml
+++ b/source/includes/steps-connect-tableau-mongosql-plugin.yaml
@@ -1,80 +1,167 @@
 title: Download the C Authentication Plugin library.
 ref: download-plugin
 level: 4
-pre: |
-  Navigate to the `releases page
-  <https://github.com/mongodb/mongosql-auth-c/releases>`_
-  and download the ``mongosql_auth`` plugin library. Save
-  the file ``mongosql_auth.so`` to the
-  ``/usr/local/mysql/lib/plugin/`` directory.
+stepnum: 1
+content: | 
+
+  Navigate to the `releases page 
+  <https://github.com/mongodb/mongosql-auth-c/releases>`_ 
+  then download the ``mongosql_auth`` plugin library.
+
+  .. list-table::
+     :widths: 20 80
+     :stub-columns: 1
+
+     * - macOS
+       - Save the library file ``mongosql_auth.so`` to the 
+         ``/usr/local/mysql/lib/plugin/`` directory.
+
+         If this directory does not exist, create it:
+
+         .. example::
+
+            .. class:: copyable-code
+            .. code-block:: sh
+
+               sudo mkdir -p /usr/local/mysql/lib/plugin -m 755
+               sudo chown -R {user}:admin /usr/local/mysql
+               tar -xvf /Users/{user}/Downloads/mongosql-auth-osx-x86_64-v{version}.tgz
+               cp /Users/{user}/Downloads/mongosql-auth-osx-x86_64/lib/mongosql_auth.so ./
+
+            .. note:: 
+
+               This example assumes you downloaded the
+               ``mongosql_auth`` plugin to the
+               ``/Users/{user}/Downloads/`` directory.
+
+               The plugin does not require MySQL or the MySQL ODBC
+               Connector to be installed.
+
+     * - Windows
+       - Run the Windows installer (``.msi``).
+
 ---
-title: Create a ``my.cnf`` file.
+title: Create a `MySQL Configuration file <https://dev.mysql.com/doc/refman/5.7/en/option-files.html>`_. (macOS only)
 ref: create-my-cnf
 level: 4
-pre: |
-  OS X
-    Create a text file with the following contents:
+content: |
 
-    .. code-block:: sh
+  a. Create a text file with the following contents:
 
-       [client]
-       default-auth=mongosql_auth
+     .. class:: copyable-code
 
-    Name the file ``my.cnf`` and save it in the directory ``/etc``.
+     .. code-block:: ini
+ 
+        [client]
+        default-auth=mongosql_auth
+
+  b. Save the file to ``/etc/my.cnf``.
+
 ---
-title: Create a ``my.tdc`` file.
-ref: create-my-tdc
+title: Create a `Tableau Datasource Connection <http://kb.tableau.com/articles/howto/using-a-tdc-file-with-tableau-server>`_ file.
+ref: create-tdc
 level: 4
-pre: |
-  OS X
-    Create a text file with the following contents:
+content: |
 
-    .. code-block:: sh
+  a. Create a text file with the following contents:
 
-       <?xml version='1.0' encoding='utf-8' ?>
-       <connection-customization class='mongodb' version='7.7' enabled='true'>
-           <vendor name='mongodb' />
-           <driver name='mongodb' />
-           <customizations>
-             <customization
-               name='odbc-connect-string-extras'
-               value='USE_MYCNF=1' />
-             </customizations>
-       </connection-customization>
+     .. list-table::
+        :widths: 20 80
+        :stub-columns: 1
+        :header-rows: 1
 
-    Name the file ``my.tdc`` and save in Tableau's ``Datasources``
-    directory. By default, Tableau creates a directory called ``My
-    Tableau Repository`` in your OS X user's ``Documents`` directory,
-    and the ``Datasources`` directory can be found there. Your
-    ``Datasources`` directory may be elsewhere, depending on your
-    system configuration. Place the ``my.tdc`` directory in the
-    repository directory you use while connecting with Tableau.
+        * - Platform
+          - TDC File Contents
+
+        * - macOS
+          - 
+
+            .. class:: copyable-code
+            .. literalinclude:: /includes/tdc/mongodb-mac.tdc
+               :language: xml
+               :emphasize-lines: 6-8
+               :linenos:
+
+        * - Windows
+          - 
+
+            .. class:: copyable-code
+            .. literalinclude:: /includes/tdc/mongodb-win.tdc
+               :language: xml
+               :emphasize-lines: 6-8
+               :linenos:
+
+  b. Save this file as ``mongodb.tdc`` in the :guilabel:`My Tableau
+     Repository` for your platform:
+
+     .. include:: /includes/list-tables/tableau-default-tdc-locations.rst
+
 ---
 title: Start Tableau.
 ref: start-tab
 level: 4
-pre: |
-  Start the Tableau Desktop application, or restart it if it was
+content: |
+  Start the Tableau Desktop application or restart it if it was
   already running.
+
+  .. include:: /includes/facts/tableau-restart.rst
+
 ---
 title: Connect using Tableau.
-ref: connect-tab
+ref: connect-tableau
 level: 4
-pre: |
-  In the left-side navigation, click on :guilabel:`More...` under
-  :guilabel:`To a server`. Select :guilabel:`MongoDB BI Connector`
-  from the list of options.
+content: |
 
-  In the connection dialog box, enter your server and port
-  information. 
+  a. In the left-side navigation under :guilabel:`To a server`, click
+     on :guilabel:`More...` then click :guilabel:`MongoDB BI
+     Connector`.
 
-  In the :guilabel:`Username` field, append the authenticating
-  database to the username. In the example shown below,
-  the user ``myTestUser`` is authenticated to use the ``test``
-  database.
+  b. In the connection dialog box:
 
-  .. figure:: /images/bi-connector/mdb-bi-connector-panel.png
-     :alt: Screenshot of Tableau with the connection panel open
-     :figwidth: 412px
+     .. list-table::
+        :widths: 20 80
+        :stub-columns: 1
+        :header-rows: 1
+
+        * - Field
+          - Action
+
+        * - :guilabel:`Server`
+          - Type the hostname or IP address of the |bi| host.
+
+        * - :guilabel:`Port`
+          - Type the 
+            :abbr:`IANA (Internet Assigned Numbers Authority)` 
+            `port number <https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml>`_ 
+            for the |bi|. The default is ``3307``.
+
+        * - :guilabel:`Username`
+          - Type the username for the user that can access the active
+            |bi| database.
+
+            Unless you specified a ``defaultMechanism`` in your
+            |bi| :ref:`Configuration File <config-format>`, you
+            must append the authenticating database to the username.
+
+            .. example::
+
+               The user ``myTestUser`` is authenticated against the
+               ``test`` database.
+
+               .. figure:: /images/bi-connector/mdb-bi-connector-panel.png
+                  :alt: Screenshot of Tableau with the connection panel open
+                  :figwidth: 412px
+           
+            - If you are using Username and Password (``SCRAM-SHA-1``)
+              authentication, the expected authenticating database is
+              ``admin``.
+            
+            - If you are using LDAP (``PLAIN``) authentication, the
+              expected authenticating database is ``$external``.
+
+        * - :guilabel:`Password`
+          - Type the password associated with the :guilabel:`Username`.
+
+  c. Click :guilabel:`Sign In`.
 
 ...

--- a/source/includes/tableau-default-tdc-locations.rst
+++ b/source/includes/tableau-default-tdc-locations.rst
@@ -1,0 +1,11 @@
+.. list-table::
+   :widths: 25 75
+   :stub-columns: 1
+   :header-rows: 1
+
+   * - Platform
+     - Default TDC Save Path
+   * - macOS
+     - /Users/{name}/Documents/My Tableau Repository/Datasources
+   * - Windows
+     - C:\Users\{username}\Documents\My Tableau Repository\Datasources

--- a/source/includes/tdc/mongodb-mac.tdc
+++ b/source/includes/tdc/mongodb-mac.tdc
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<connection-customization class='mongodb' version='7.7' enabled='true'>
+  <vendor name='mongodb' />
+  <driver name='mongodb' />
+  <customizations>
+    <customization
+      name='odbc-connect-string-extras'
+      value='USE_MYCNF=1' />
+  </customizations>
+</connection-customization>

--- a/source/includes/tdc/mongodb-ssl.tdc
+++ b/source/includes/tdc/mongodb-ssl.tdc
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<connection-customization class='mongodb' version='7.7' enabled='true'>
+  <vendor name='mongodb' />
+  <driver name='mongodb' />
+  <customizations>
+    <customization
+      name='odbc-connect-string-extras'
+      value='SSLKEY={C:\path_to_key\mongodb.key};
+             SSLCERT={C:\path_to_cert\mongodb.crt};
+             SSLCA={C:\path_to_CAcert\ca.crt};
+             ENABLE_CLEARTEXT_PLUGIN=1;
+             SSL_ENFORCE=1' />
+  </customizations>
+</connection-customization>

--- a/source/includes/tdc/mongodb-win.tdc
+++ b/source/includes/tdc/mongodb-win.tdc
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<connection-customization class='mongodb' version='7.7' enabled='true'>
+  <vendor name='mongodb' />
+  <driver name='mongodb' />
+  <customizations>
+    <customization
+      name='odbc-connect-string-extras'
+      value='DEFAULT_AUTH=mongosql_auth' />
+  </customizations>
+</connection-customization>

--- a/source/tutorial/connecting.txt
+++ b/source/tutorial/connecting.txt
@@ -58,7 +58,7 @@ username as URI-style query parameters:
 
 .. list-table::
    :header-rows: 1
-   :widths: 30 70
+   :widths: 25 75
 
    * - Connection Option
      - Description
@@ -77,7 +77,7 @@ username as URI-style query parameters:
    * - .. urioption:: mechanism
 
      - Specify the mechanism that the |bi| should use to
-       authenticate the connection. Possible values include:
+       authenticate the connection. Accepted values include:
 
        - :ref:`SCRAM-SHA-1 <authentication-scram-sha-1>`
        - :ref:`PLAIN <security-auth-ldap>` (LDAP SASL)
@@ -85,7 +85,8 @@ username as URI-style query parameters:
        The ``PLAIN`` (LDAP) mechanism requires MongoDB Enterprise, and
        requires that :urioption:`source` be ``$external``.
 
-       .. note:: Kerberos is not supported.
+       .. note:: 
+          Neither Kerberos (``GSSAPI``) nor x.509 are supported.
 
 .. example::
    To authenticate as the user ``grace`` with authentication
@@ -161,6 +162,31 @@ Connect with Tableau
 
 .. _connect-with-tableau:
 
+Connect from Tableau without Authentication or TLS/SSL
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Click on the :guilabel:`MongoDB BI Connector` named connection in
+Tableau's left hand column. Enter the host and port on which
+:program:`mongosqld` is listening, and click :guilabel:`Sign In` to
+connect.
+
+By default, :program:`mongosqld` binds to port ``3307``.
+
+.. figure:: /images/bi-connector/tableau-pick-bi-connector.png
+   :alt: Screenshot of Tableau with the MongoDB Connector for BI item selected
+   :figwidth: 662px
+
+   Tableau with the MongoDB Connector for BI item selected
+
+
+.. figure:: /images/bi-connector/bi-connector-named-connection.png
+   :alt: Screenshot of Tableau with the MongoDB Connector for BI connection panel open
+   :figwidth: 520px
+
+   MongoDB Connector for BI connection panel
+
+.. _connect-tableau-cauth:
+
 .. versionadded:: 2.2
 
 Connect from Tableau with the C Authentication Plugin
@@ -168,35 +194,13 @@ Connect from Tableau with the C Authentication Plugin
 
 .. include:: /includes/steps/connect-tableau-mongosql-plugin.rst
 
-Connect from Tableau without Authentication or TLS/SSL
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Click on the :guilabel:`MySQL` named connection in Tableau's left hand
-column. Enter the host and port on which :program:`mongosqld` is
-listening, and click :guilabel:`Sign In` to connect.
-
-By default, :program:`mongosqld` binds to port ``3307``.
-
-.. figure:: /images/bi-connector/tableau.png
-   :alt: Screenshot of Tableau with the MySQL connection panel open
-   :figwidth: 700px
-
 .. _connect-tableau-auth:
 
 Connect from Tableau with Authentication and TLS/SSL
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To connect Tableau to the |bi| using TLS/SSL, you must configure
-Tableau to send passwords in clear text either by using
-a Tableau Datasource Connection (TDC) file, or by setting the
-``LIBMYSQL_ENABLE_CLEARTEXT_PLUGIN`` environment variable.
-
-Using a TDC File
-````````````````
+Tableau to send passwords in clear text. Create a Tableau Datasource
+Connection (``.tdc``) file to enable that setting.
 
 .. include:: /includes/steps/connect-tableau-authentication-tdc.rst
-
-Using an Environment Variable
-`````````````````````````````
-
-.. include:: /includes/steps/connect-tableau-authentication-envvar.rst


### PR DESCRIPTION
@steveren : I updated the Tableau section with all of the appropriate information. It is [staged](https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/anthonysansone/DOCSP-970/tutorial/connecting.html#connect-with-tableau).