### PR TITLE
(DOCSP-658): Added logRotate.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ build/
 meta.yaml
 fabfile
 giza.log
+backups
 

--- a/source/includes/options-mongosqld.yaml
+++ b/source/includes/options-mongosqld.yaml
@@ -94,7 +94,7 @@ description: |
 
      Similarly, instead of enabling :urioption:`ssl` in the connection string,
      run {{program}} with :option:`--mongo-ssl`.
-  
+
   URI options not in the list above *nor* in the list of supported {{program}}
   :ref:`options <mongosqld-command-line-options>` are not supported.
 
@@ -245,15 +245,15 @@ description: |
   authentication mechanisms
   ``GSSAPI`` and ``PLAIN`` use the ``$external`` source, while
   ``SCRAM-SHA-1`` uses a MongoDB database as its source.
-  
+
   If no value is given for this option it defaults to the the
   MongoDB ``admin`` database.
-  
+
   The ``$external`` authentication source stores a reference
   to system users in a MongoDB database called ``$external``,
   but the credentials are stored in an external,
   non-MongoDB system, such as an LDAP server.
-  
+
   Any connection which uses the default value can omit the
   ``source`` parameter from its :ref:`MySQL <connect-mysql-auth>`
   or :ref:`Tableau <connect-tableau-auth>` username.
@@ -280,6 +280,27 @@ args: null
 description: |
   Append new logging output to an existing log file specified by
   :option:`--logPath`.
+
+  Requires :option:`--logRotate`.
+optional: true
+---
+program: mongosqld
+name: logRotate
+directive: option
+args: reopen | rename
+description: |
+  Specifies that you want to rotate logs and how they should be rotated.
+
+  When this option is set, the logs rotate when you issue a ``FLUSH LOGS``
+  command to the |bi| or when you restart ``mongosqld``.
+
+  If you set :option:`--logRotate` to ``rename``:
+    The existing log file is closed, a timestamp is appended, and a new
+    log file is created.
+
+  If you set :option:`--logRotate` to ``reopen``:
+    The existing log file is closed and reopened.
+default: rename
 optional: true
 ---
 program: mongosqld
@@ -353,7 +374,7 @@ description: |
   .. versionadded:: 2.2
 
   Specifies the maximum length, in characters, for all varchar fields. If
-  {{program}} encounters a string that is longer than the maximum length, 
+  {{program}} encounters a string that is longer than the maximum length,
   {{program}} truncates it to the maximum length and logs a warning.
 optional: true
 ...

--- a/source/reference/mongosqld.txt
+++ b/source/reference/mongosqld.txt
@@ -68,6 +68,8 @@ Log Options
 
 .. include:: /includes/option/option-mongosqld-logPath.rst
 
+.. include:: /includes/option/option-mongosqld-logRotate.rst
+
 .. include:: /includes/option/option-mongosqld-verbose.rst
 
 .. include:: /includes/option/option-mongosqld-quiet.rst
@@ -145,6 +147,7 @@ Logging Options
 
    systemLog:
      logAppend: <boolean>
+     logRotate: "rename"|"reopen"
      path: <string>
      quiet: <boolean>
      verbosity: <integer>
@@ -159,6 +162,10 @@ Logging Options
    * - .. setting:: systemLog.logAppend
      - boolean
      - :option:`--logAppend`
+
+   * - .. setting:: systemLog.logRotate
+     - string
+     - :option:`--logRotate`
 
    * - .. setting:: systemLog.path
      - string
@@ -241,7 +248,7 @@ Network Options
    * - .. setting:: net.bindIp
      - string
      - The hostname component of :option:`--addr`
-       
+
        .. versionchanged:: 2.2
           To bind to multiple IP addresses, enter a list of comma separated values.
 
@@ -453,7 +460,7 @@ Atlas uses TLS/SSL to encrypt connections and enforces authentication by
 default.
 
 .. note::
-   
+
    With the MongoDB Atlas free tier, |bi-short| cannot run aggregation pipelines
    using the ``allowDiskUse`` option. This option allows aggregation stages to
    write data as temporary files to disk. To review the MongoDB Atlas free


### PR DESCRIPTION
@i80and , @rychipman : Just added the `logRotate` option to the `mongosqld` page. 

- [Staged: option](https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/anthonysansone/DOCSP-658/reference/mongosqld.html#cmdoption-logrotate)
- [Staged: Conf File](https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/anthonysansone/DOCSP-658/reference/mongosqld.html#logging-options)