### PR TITLE
(DOCSP-1051): Added USING to supported operations.

### DIFF
--- a/source/includes/options-mongosqld.yaml
+++ b/source/includes/options-mongosqld.yaml
@@ -92,7 +92,7 @@ description: |
 
   The number of documents per database to sample when gathering schema
   information.
-default: 1000  
+default: 1000
 ---
 program: mongosqld
 name: sampleMode
@@ -135,10 +135,12 @@ name: mongo-versionCompatibility
 directive: option
 args: <version-number>
 description: |
-  Specifies that {{program}} must only use features supported by the
-  specified version of MongoDB. Only necessary when used with
-  replica sets in which members use different MongoDB versions.
-  The minimum allowable MongoDB version is ``3.2``.
+
+  Restricts {{program}} to using features that the specified version of
+  MongoDB supports. Only necessary when used with replica sets in which
+  members use different MongoDB versions. Requires MongoDB version 3.2
+  or later.
+
 ---
 program: mongosqld
 name: mongo-uri


### PR DESCRIPTION
Added `USING` to supported options and fixed error with `mongosqld`.