### PR TITLE
(DOCSP-1287,-88): Added INTERVAL, MICROSECOND to supported SQL operations

### DIFF
--- a/source/supported-operations.txt
+++ b/source/supported-operations.txt
@@ -44,8 +44,8 @@ Comparison Functions and Operators
    * - ``IN()``
      - Check whether a value is within a set of values
    * - ``INTERVAL(N,N1,N2,...)``
-     - Return 0-based index position of last number in the list to be ``< N``.
-       Return ``-1`` if ``N`` is ``NULL``
+     - Return the 0-based index position of last number in the list to be 
+       ``< N``. Return ``-1`` if ``N`` is ``NULL``
      
        ``N1``, ``N2``, etc. must be given in ascending order. 
 
@@ -55,7 +55,9 @@ Comparison Functions and Operators
 
              SELECT INTERVAL(26, 2, 9, 12, 28.5, 62, 2300);
           
-          Returns ``3``
+          Returns ``3`` because ``12`` is the last number in the list 
+          less than ``26``.
+
    * - ``IS``
      - Test a value against a boolean
    * - ``IS NOT``
@@ -110,21 +112,21 @@ JOIN Expressions
    * - Expression
      - Description
 
-   * - JOIN
+   * - ``JOIN``
      - Select records that have matching values in multiple tables.
 
-   * - INNER JOIN
-     - Semantically equivalent to JOIN.
+   * - ``INNER JOIN``
+     - Semantically equivalent to ``JOIN``.
 
-   * - LEFT JOIN
+   * - ``LEFT JOIN``
      - Return all records from the left table, and the matched records
        from the right table.
 
-   * - RIGHT JOIN
+   * - ``RIGHT JOIN``
      - Return all records from the right table, and the matched records
        from the left table.
 
-   * - NATURAL JOIN
+   * - ``NATURAL JOIN``
      - Return only records which do not appear in both tables.
 
 Control Flow Functions and Operators
@@ -345,8 +347,8 @@ Date and Time Functions
    * - ``MAKEDATE()``
      - Create a date from the year and day of year
    * - ``MICROSECOND()``
-     - Return the microseconds from the time or datetime expression 
-       ``<expr>`` as a number in the range from 0 to 999999.
+     - Return the microseconds from the input time or datetime expression 
+       as a number between 0 and 999999 inclusive.
    * - ``MINUTE()``
      - Return the minute from the argument
    * - ``MONTH()``

--- a/source/supported-operations.txt
+++ b/source/supported-operations.txt
@@ -43,6 +43,19 @@ Comparison Functions and Operators
      - Return the largest argument
    * - ``IN()``
      - Check whether a value is within a set of values
+   * - ``INTERVAL(N,N1,N2,...)``
+     - Return 0-based index position of last number in the list to be ``< N``.
+       Return ``-1`` if ``N`` is ``NULL``
+     
+       ``N1``, ``N2``, etc. must be given in ascending order. 
+
+       .. example::
+
+          .. code-block:: sql
+
+             SELECT INTERVAL(26, 2, 9, 12, 28.5, 62, 2300);
+          
+          Returns ``3``
    * - ``IS``
      - Test a value against a boolean
    * - ``IS NOT``
@@ -331,6 +344,9 @@ Date and Time Functions
      - Return the last day of the month for the argument
    * - ``MAKEDATE()``
      - Create a date from the year and day of year
+   * - ``MICROSECOND()``
+     - Return the microseconds from the time or datetime expression 
+       ``<expr>`` as a number in the range from 0 to 999999.
    * - ``MINUTE()``
      - Return the minute from the argument
    * - ``MONTH()``


### PR DESCRIPTION
@jeff-allen-mongo : Quick change for you. [Staged](https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/anthonysansone/DOCSP-1287/supported-operations.html#comparison-functions-and-operators).