### PR TITLE
(DOCS-10897, DOCSP-1091, -1281): Added Windows examples, 32-bit compatibility. SSL Compatibility.

### DIFF
--- a/source/connect/mysql.txt
+++ b/source/connect/mysql.txt
@@ -106,6 +106,17 @@ password after the command has been entered.
 Connect from MySQL with Authentication and TLS/SSL
 --------------------------------------------------
 
+.. important::
+
+   The `binary distribution of MySQL Community 
+   <https://dev.mysql.com/doc/refman/5.7/en/openssl-versus-yassl.html>`_ 
+   uses the `yaSSL <https://www.wolfssl.com/products/yassl/>`_ 
+   :abbr:`SSL (Secure Sockets Layer)` library to encrypt connections.
+   MySQL Enterprise uses `OpenSSL <https://www.openssl.org/>`_ which is
+   compatible with |bi|. Use MySQL Enterprise to connect to |bi-short| 
+   over :abbr:`TLS (Transport Layer Security)` /
+   :abbr:`SSL (Secure Sockets Layer)`.
+
 To connect to a :program:`mongosqld` instance listening on port ``3307``,
 as user ``grace`` using authentication mechanism ``PLAIN``, and using
 specific TLS/SSL CA and x.509 certificates, run the following command:

--- a/source/connect/mysql.txt
+++ b/source/connect/mysql.txt
@@ -22,10 +22,31 @@ Connect from MySQL without Authentication or TLS/SSL
 To connect to a :program:`mongosqld` instance listening on the MySQL
 default port ``3307``, run the following command:
 
+macOS and Linux
+~~~~~~~~~~~~~~~
+
 .. cssclass:: copyable-code
 .. code-block:: sh
 
    mysql --protocol tcp --port 3307
+
+32-bit Windows
+~~~~~~~~~~~~~~
+
+.. cssclass:: copyable-code
+.. code-block:: ps1
+
+   "C:\Program Files (x86)\MySQL\MySQL Server 5.7\bin\mysql.exe" ^
+     --protocol tcp --port 3307
+
+64-bit Windows
+~~~~~~~~~~~~~~
+
+.. cssclass:: copyable-code
+.. code-block:: ps1
+
+   "C:\Program Files\MySQL\MySQL Server 5.7\bin\mysql.exe" ^
+     --protocol tcp --port 3307
 
 .. _connect-mysql-auth:
 
@@ -45,15 +66,40 @@ password after the command has been entered.
 
    mysql '--user=reportsUser?source=admin' --default-auth=mongosql_auth -p
 
-This example assumes that the authentication plugin file
-``mongosql_auth.so`` is located in the default MySQL plugin folder.
-The location of the plugin folder varies by platform, but you can
-locate it by running the following command:
+.. note::
+
+   This example assumes that the authentication plugin file
+   ``mongosql_auth.so`` is located in the default MySQL plugin folder.
+   The location of the plugin folder varies by platform, but you can
+   locate it by running the following command:
+
+   .. cssclass:: copyable-code
+   .. code-block:: sh
+
+      mysql_config --plugindir
+
+   ``mysql_config.pl`` can find the plugin directory only on macOS and 
+   Linux hosts.
+
+32-bit Windows
+~~~~~~~~~~~~~~
 
 .. cssclass:: copyable-code
-.. code-block:: sh
+.. code-block:: ps1
 
-   mysql_config --plugindir
+   "C:\Program Files (x86)\MySQL\MySQL Server 5.7\bin\mysql.exe" ^
+     '--user=reportsUser?source=admin' ^
+     --default-auth=mongosql_auth -p
+
+64-bit Windows
+~~~~~~~~~~~~~~
+
+.. cssclass:: copyable-code
+.. code-block:: ps1
+
+   "C:\Program Files\MySQL\MySQL Server 5.7\bin\mysql.exe" ^
+     '--user=reportsUser?source=admin' ^
+     --default-auth=mongosql_auth -p
 
 .. _connect-with-tls-ssl:
 
@@ -64,6 +110,9 @@ To connect to a :program:`mongosqld` instance listening on port ``3307``,
 as user ``grace`` using authentication mechanism ``PLAIN``, and using
 specific TLS/SSL CA and x.509 certificates, run the following command:
 
+macOS and Linux
+~~~~~~~~~~~~~~~
+
 .. cssclass:: copyable-code
 .. code-block:: sh
 
@@ -72,6 +121,34 @@ specific TLS/SSL CA and x.509 certificates, run the following command:
      --ssl-ca=/path_to_the_CAcert/ca.crt \
      --ssl-key=/path_to_my_certificate_key/mysql.key \
      --ssl-cert=/path_to_my_client_certificate/mysql.crt \
+     -p
+
+32-bit Windows
+~~~~~~~~~~~~~~
+
+.. cssclass:: copyable-code
+.. code-block:: cmd
+
+   "C:\Program Files (x86)\MySQL\MySQL Server 5.7\bin\mysql.exe" ^
+     --enable-cleartext-plugin --protocol tcp --port 3307 ^
+     -u 'grace?mechanism=PLAIN&source=$external' ^
+     --ssl-ca=X:\path_to_the_CAcert\ca.crt ^
+     --ssl-key=X:\path_to_my_certificate_key\mysql.key ^
+     --ssl-cert=X:\path_to_my_client_certificate\mysql.crt ^
+     -p
+
+64-bit Windows
+~~~~~~~~~~~~~~
+
+.. cssclass:: copyable-code
+.. code-block:: ps1
+
+   "C:\Program Files\MySQL\MySQL Server 5.7\bin\mysql.exe" ^
+     --enable-cleartext-plugin --protocol tcp --port 3307 ^
+     -u 'grace?mechanism=PLAIN&source=$external' ^
+     --ssl-ca=X:\path_to_the_CAcert\ca.crt ^
+     --ssl-key=X:\path_to_my_certificate_key\mysql.key ^
+     --ssl-cert=X:\path_to_my_client_certificate\mysql.crt ^
      -p
 
 If using the ``$external`` authentication source, wrap your username in

--- a/source/reference/auth-plugin-c.txt
+++ b/source/reference/auth-plugin-c.txt
@@ -26,28 +26,32 @@ This plugin supports the following authentication mechanisms:
 Supported Platforms
 -------------------
 
-The plugin is built and tested on the following platforms (all x86\_64):
+The plugin is built and tested on the following platforms:
 
-- Windows 2008 R2
+- Windows 2008 R2 (32- and 64-bit)
 
-- OSX 10.12
+- macOS 10.12 (64-bit)
 
-- Ubuntu 14.04
+- Ubuntu 14.04 (64-bit)
 
-- RHEL 7.0
+- RHEL 7.0 (all 64-bit)
 
-The plugin is built against MySQL 5.7.18 Community Edition (64-bit),
-and tested with MySQL 5.7.18 Community Edition and the MongoDB
-Connector for BI 2.2.
 
-Install
--------
+.. admonition:: Testing Environment
+   :class: note
+
+   The plugin was developed against MySQL 5.7.18 Community Edition
+   (64-bit), and tested with MySQL 5.7.18 Community Edition and the
+   MongoDB Connector for BI 2.2+.
+
+Installing the Plugin
+---------------------
 
 Windows
 ~~~~~~~
 
-#. Download the `MySQL 5.7.18 installer
-   <https://dev.mysql.com/downloads/file/?id=470091>`_ and install the
+#. Download the `MySQL 5.7.x installer
+   <https://dev.mysql.com/downloads/windows/installer/5.7.html>`_ and install the
    products needed.
 
 #. Download the ``mongosql_auth`` plugin component `.msi installer
@@ -79,28 +83,32 @@ MacOS and Linux
      ``plugin-dir=<your-install-dir>`` option to your MySQL client. See
      the :ref:`mysql client command example <mysql-example-command>`.
 
-Usage
------
+Using the Plugin for Authentication
+-----------------------------------
 
 The exact procedure for using the C Authentication plugin library
 varies depending on your SQL client. 
 
-This plugin can be used with the 64-bit version of the the MySQL shell
-and the MySQL ODBC driver.
+This plugin can be used with either the 32-bit or 64-bit version of the
+the MySQL shell and the MySQL ODBC driver. The installation directory
+differs depending on the version you install.
 
 .. _mysql-command-options:
 
 ``mysql`` Options
 ~~~~~~~~~~~~~~~~~
 
-The following table lists some ``mysql`` command-line options available for
-use with ``mongosql_auth``. For a complete list of command line
-options, refer to the `MySQL client documentation
-<https://dev.mysql.com/doc/refman/5.7/en/mysql.html>`_.
+The following table lists some ``mysql`` command-line options available
+for use with ``mongosql_auth``. 
+
+.. seealso::
+
+   A complete list of command line can be found in the 
+   `MySQL client documentation <https://dev.mysql.com/doc/refman/5.7/en/mysql.html>`_.
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 30 30
+   :widths: 20 20 60
 
    * - Option
      - Value
@@ -134,21 +142,35 @@ options, refer to the `MySQL client documentation
 
    * - ``--plugin-dir``
      - ``<your-plugin-dir>``
-     - Optional. Defaults to ``<mysql-home>/lib/plugin/``.
+     - Optional. 
+
+       .. list-table::
+          :widths: 25 75
+          :header-rows: 1
+
+          * - Platform
+            - Default Location
+          * - macOS, Linux
+            - ``<mysql-home>/lib/plugin/``
+          * - 32-bit Windows
+            - ``"C:\Program Files (x86)\MySQL\MySQL Server 5.7\lib\plugin"``
+          * - 64-bit Windows
+            - ``"C:\Program Files\MySQL\MySQL Server 5.7\lib\plugin"`` 
 
 .. _mysql-example-command:
 
-Example Command
-~~~~~~~~~~~~~~~
+.. example::
 
-.. cssclass:: copyable-code
-.. code-block:: sh
+   The following command specifies the username ``myTestUser``
+   who is authenticated for the database ``test``. The shell prompts 
+   the user for a password.
 
-   mysql '--user=myTestUser?source=test&mechanism=SCRAM-SHA-1' --default-auth=mongosql_auth --plugin-dir=/usr/bin/mysql/plugins -p
+   .. cssclass:: copyable-code
+   .. code-block:: sh
 
-The above command specifies the user with username ``myTestUser``
-who is authenticated for the database ``test``. The shell will prompt
-the user for a password.
+      mysql '--user=myTestUser?source=test&mechanism=SCRAM-SHA-1' \
+        --default-auth=mongosql_auth \
+        --plugin-dir=/usr/bin/mysql/plugins -p
 
 .. _odbc-connection:
 
@@ -158,7 +180,7 @@ ODBC Connection Parameter
 If you are using the MySQL ODBC driver, the interface you use to
 configure your :abbr:`DSN (Data Source Name)` may provide a
 field where you can specify the default authentication
-plugin to use. Specifying ``mongosql_auth`` here will cause the
+plugin to use. Specifying ``mongosql_auth`` in that field causes the
 ODBC driver to use the ``mongosql_auth`` plugin by default.
  
 .. _mysql-config: 
@@ -166,55 +188,93 @@ ODBC driver to use the ``mongosql_auth`` plugin by default.
 Configuration File
 ~~~~~~~~~~~~~~~~~~
 
-MySQL configuration files can be found in many locations, as listed
-in the `MySQL documentation
-<https://dev.mysql.com/doc/refman/5.7/en/option-files.html>`_.
-In one of these files, add a line with ``default-auth=mongosql_auth`` to
-the ``[client]`` section or create it if it does not yet exist.
-To use this same configuration file with an ODBC :abbr:`DSN
-(Data Source Name)`, provide the ``USE_MYCNF=1`` connection parameter
-to your ODBC :abbr:`DSN (Data Source Name)`.
+MySQL configuration files can be found in many locations, as listed in
+the `MySQL documentation <https://dev.mysql.com/doc/refman/5.7/en/option-files.html>`_. 
+In one of these files, add a line with ``default-auth=mongosql_auth`` 
+to the ``[client]`` section. Create the ``[client]`` section if it does not exist. 
 
-Example Steps: Using the C Authentication Plugin
-------------------------------------------------
+To use this configuration file with an
+:abbr:`ODBC (Open Database Connectivity)` 
+:abbr:`DSN (Data Source Name)`, add the ``USE_MYCNF=1`` connection 
+parameter to your :abbr:`ODBC (Open Database Connectivity)`
+:abbr:`DSN (Data Source Name)`.
 
-#. If you haven't yet set up authenticated users for MongoDB, do that
-   first. See :manual:`Enable Authentication
-   </tutorial/enable-authentication/>` for more information.
+Using the C Authentication Plugin
+---------------------------------
 
-#. Start a :term:`mongod` instance with the ``--auth`` option. See
-   :manual:`Authentication </core/authentication/>` for more
-   information about starting ``mongod`` with security enabled.
+#. If you have not yet set up authenticated users for MongoDB, do that
+   first. 
 
-#. Start :program:`mongosqld` with the ``--auth`` option. See
-   :doc:`/installation` for more information about starting ``mongosqld``.
+   To learn how to create authenticated users, see 
+   :manual:`Enable Authentication
+   </tutorial/enable-authentication/>`.
+
+#. Start a :term:`mongod` instance with the ``--auth`` option. 
+
+   To learn how to start ``mongod`` with security enabled. see
+   :manual:`Authentication </core/authentication/>` .
+
+#. Start :program:`mongosqld` with the ``--auth`` option. 
+
+   To learn how to start ``mongosqld``, see 
+   :ref:`Start the BI Connector Service <start-mongosqld-system-service>`.
+
+   **macOS and Linux:**
 
    .. cssclass:: copyable-code   
    .. code-block:: sh
    
       mongosqld --schema schema.drdl --auth
 
+   **Windows:**
+
+   .. cssclass:: copyable-code   
+   .. code-block:: ps1
+
+      "C:\Program Files\MongoDB\Connector for BI\{version}\bin\mongosqld.exe" ^
+         --schema schema.drdl --auth
+
 #. Connect to :program:`mongosqld` with your client program, using the
    ``default-auth=mongosql_auth`` option. The connection command
    varies by client, but with the MySQL shell the command is as
    follows:
 
-   .. cssclass:: copyable-code   
-   .. code-block:: sh
+   .. example::
 
-      mysql --user=<username>?source=<some-db> --default-auth=mongosql_auth -p
+      **macOS and Linux:**
 
-In the above command, ``<some-db>`` should be the database for which
-the user is authenticated. The shell will prompt the user for a password.
-See the :ref:`table above <mysql-command-options>` for
-additional options.
+      .. cssclass:: copyable-code   
+      .. code-block:: sh
 
-Notes
------
+         mysql --user=<username>?source=<some-db> --default-auth=mongosql_auth -p
 
-- The ``SCRAM-SHA-1`` mechanism hashes the passwords in the client
-  plugin; however, all other data is in cleartext. If possible, use
-  with encrypted connections.
+      **32-bit Windows:**
 
-- The ``PLAIN`` mechanism sends the password in cleartext. As such, if
-  possible, you should only use with encrypted connections.
+      .. cssclass:: copyable-code   
+      .. code-block:: cmd
+
+         "C:\Program Files (x86)\MySQL\MySQL Server 5.7\bin\mongosqld.exe" ^
+            --user=<username>?source=<some-db> --default-auth=mongosql_auth -p
+
+      **64-bit Windows:**
+
+      .. cssclass:: copyable-code   
+      .. code-block:: ps1
+
+         "C:\Program Files\MySQL\MySQL Server 5.7\bin\mongosqld.exe" ^
+            --user=<username>?source=<some-db> --default-auth=mongosql_auth -p
+
+      ``<some-db>`` should be the database on which
+      you can authenticate. The shell prompts you for a password.
+
+For additional options, see the 
+:ref:`MySQL Commands <mysql-command-options>`.
+
+.. note::
+
+   - The ``SCRAM-SHA-1`` mechanism hashes the passwords in the client
+     plugin; however, all other data is in cleartext. If possible, use 
+     with encrypted connections.
+
+   - The ``PLAIN`` mechanism sends the password in cleartext. Use 
+     encrypted connections with the ``PLAIN`` mechanism .

--- a/source/reference/auth-plugin-c.txt
+++ b/source/reference/auth-plugin-c.txt
@@ -34,7 +34,7 @@ The plugin is built and tested on the following platforms:
 
 - Ubuntu 14.04 (64-bit)
 
-- RHEL 7.0 (all 64-bit)
+- RHEL 7.0 (64-bit)
 
 
 .. admonition:: Testing Environment

--- a/source/tutorial/install-auth-plugin-c.txt
+++ b/source/tutorial/install-auth-plugin-c.txt
@@ -32,13 +32,13 @@ Supported Platforms
 
 The plugin is built and tested on the following platforms (all x86\_64):
 
-- Windows 2008 R2
+- Windows 2008 R2 (32- and 64-bit)
 
-- OSX 10.12
+- macOS 10.12 (64-bit)
 
-- Ubuntu 14.04
+- Ubuntu 14.04 (64-bit)
 
-- RHEL 7.0
+- RHEL 7.0 (all 64-bit)
 
 The plugin is built against MySQL 5.7.18 Community Edition (64-bit),
 and tested with MySQL 5.7.18 Community Edition and the MongoDB
@@ -54,6 +54,20 @@ Install ``mongosql_auth`` on Windows
 #. Download the ``mongosql_auth`` plugin component `.msi installer
    <https://github.com/mongodb/mongosql-auth-c/releases>`_ and install the
    ``mongosql_auth`` plugin component.
+
+   The plugin is installed into one of the following directories depending on
+   platform:
+
+   .. list-table::
+      :widths: 25 75
+      :header-rows: 1
+
+      * - Platform
+        - Default Location
+      * - 32-bit Windows
+        - ``C:\Program Files (x86)\MySQL\MySQL Server 5.7\lib\plugin``
+      * - 64-bit Windows
+        - ``C:\Program Files\MySQL\MySQL Server 5.7\lib\plugin``
 
 Install ``mongosql_auth`` on MacOS or Linux
 -------------------------------------------


### PR DESCRIPTION
@jeff-allen-mongo : Added information on Windows 32-bit support for BI Connector and a few Windows examples.

- [x] [C Auth Reference](https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/anthonysansone/DOCS-10897/reference/auth-plugin-c.html)

- [x] [C Auth Install](https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/anthonysansone/DOCS-10897/tutorial/install-auth-plugin-c.html)