### PR TITLE
DOCSP-1009: add MySQL shell step to MacOS/Linux C auth plugin install…

### DIFF
--- a/source/tutorial/install-auth-plugin-c.txt
+++ b/source/tutorial/install-auth-plugin-c.txt
@@ -47,9 +47,10 @@ Connector for BI 2.2.
 Install ``mongosql_auth`` on Windows
 ------------------------------------
 
-#. Download the `MySQL 5.7.18 installer
-   <https://dev.mysql.com/downloads/file/?id=470091>`_ and install the
-   products needed.
+#. Download the `MySQL 5.7.x installer
+   <https://dev.mysql.com/downloads/mysql/>`_ and install the
+   MySQL Community Server, which includes the MySQL shell
+   (``mysql.exe``).
 
 #. Download the ``mongosql_auth`` plugin component `.msi installer
    <https://github.com/mongodb/mongosql-auth-c/releases>`_ and install the
@@ -71,6 +72,10 @@ Install ``mongosql_auth`` on Windows
 
 Install ``mongosql_auth`` on MacOS or Linux
 -------------------------------------------
+
+#. Download the `MySQL 5.7.x installer
+   <https://dev.mysql.com/downloads/mysql/>`_ and install the
+   MySQL Community Server, which includes the MySQL shell.
 
 #. Download ``mongosql_auth`` plugin library from  the
    `releases page <https://github.com/mongodb/mongosql-auth-c/releases>`_.


### PR DESCRIPTION
…ation instructions

Staged: https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/steverenaker/DOCSP-1009/tutorial/install-auth-plugin-c.html

Updated the MySQL shell step for the Windows installation to make it less brittle and added the step to the MacOS/Linux instructions.