### PR TITLE
(DOCSP-1519): Fix MySQL examples.

### DIFF
--- a/source/reference/auth-plugin-c.txt
+++ b/source/reference/auth-plugin-c.txt
@@ -179,7 +179,7 @@ for use with ``mongosql_auth``.
    .. cssclass:: copyable-code   
    .. code-block:: bat
 
-      "C:\Program Files (x86)\MySQL\MySQL Server 5.7\bin\mongosqld.exe" ^
+      "C:\Program Files (x86)\MySQL\MySQL Server 5.7\bin\mysql.exe" ^
         --default-auth=mongosql_auth ^
         --plugin-dir=/usr/bin/mysql/plugins -p
 
@@ -188,7 +188,7 @@ for use with ``mongosql_auth``.
    .. cssclass:: copyable-code   
    .. code-block:: ps1
 
-      "C:\Program Files\MySQL\MySQL Server 5.7\bin\mongosqld.exe" ^
+      "C:\Program Files\MySQL\MySQL Server 5.7\bin\mysql.exe" ^
         --default-auth=mongosql_auth ^
         --plugin-dir=/usr/bin/mysql/plugins -p
 


### PR DESCRIPTION
Changed example to `mysql.exe` from `mongosqld.exe`.