### PR TITLE
DOCS-11111: Certificate designation is incorrect for --sslPEMKeyFile …

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -149,12 +149,13 @@ option. For example:
 Connecting a client to ``mongosqld``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To specify a TLS/SSL CA root certificate, use the :option:`--sslCAFile <mongosqld --mongo-sslCAFile>`
-option. To specify a client certificate, use the :option:`--sslPEMKeyFile <mongosqld --mongo-sslPEMKeyFile>`
-option. For example:
+To specify a TLS/SSL CA root certificate, use the
+:option:`--sslCAFile <mongosqld --mongo-sslCAFile>` option. To specify
+a server certificate, use the :option:`--sslPEMKeyFile
+<mongosqld --mongo-sslPEMKeyFile>` option. For example:
 
 .. code-block:: sh
 
    mongosqld --schema=schema.drdl \
              --sslCAFile=/certs/ca.pem \
-             --sslPEMKeyFile=/certs/mysql_client.pem
+             --sslPEMKeyFile=/certs/mongosql_server.pem


### PR DESCRIPTION
…option

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs-bi-connector/91)
<!-- Reviewable:end -->
