### PR TITLE
DOCSP-1686 & DOCSP-1687 - Fix incorrect service name.  Clarify runnin…

### DIFF
--- a/source/includes/steps-install-bi-connector-debian.yaml
+++ b/source/includes/steps-install-bi-connector-debian.yaml
@@ -41,62 +41,96 @@ source:
   ref: generate-schema
 ---
 stepnum: 4
-ref: edit-config-file-debian
+ref: start-mongosqld-debian
 level: 4
 source:
   file: steps-install-bi-connector.yaml
-  ref: edit-config-file
+  ref: start-mongosqld
+action:
+  - heading: "Start ``mongosqld`` manually:"
+    content: |
+      Using Command Line Options
+      --------------------------
+
+      .. cssclass:: copyable-code
+      .. code-block:: sh
+
+         mongosqld
+
+      For the list of command line options, see
+      :ref:`mongosqld-command-line-options`.
+
+      Using a Configuration File
+      --------------------------
+
+      Using your preferred text editor, create a ``mongosqld.conf`` file.
+      To review the configuration file options, see :ref:`Configuration
+      File <config-format>`.
+
+      .. cssclass:: copyable-code
+      .. code-block:: sh
+
+         mongosqld --config <pathToConfigFile>/mongosqld.conf
+
+  - heading: "Start ``mongosqld`` as a system service:"
+    content: |
+      The |bi-short| requires a configuration file with the
+      :setting:`systemLog.path` setting specified when running as a
+      system service. Using your preferred text editor, create a
+      ``mongosqld.conf`` file. To review the configuration file options,
+      see :ref:`Configuration File <config-format>`. For example:
+      
+      .. cssclass:: copyable-code
+      .. code-block:: text
+
+         systemLog:
+           path: '/logs/mongosqld.log'
+         net:
+           bindIp: "127.0.0.1"
+           port: 3307
+
+      Debian 7.x (Wheezy):
+      --------------------
+      
+      .. cssclass:: copyable-code
+      .. code-block:: sh
+
+         mongosqld install --config <pathToConfigFile>/mongosqld.conf
+         service mongosql start
+
+      To enable the service so it starts automatically at boot time, run
+      the following:
+
+      .. cssclass:: copyable-code
+      .. code-block:: sh
+
+         chkconfig mongosql on
+
+      RHEL 7.x / CentOS 7.x and SUSE 12:
+      ----------------------------------
+
+      .. cssclass:: copyable-code
+      .. code-block:: sh
+
+         mongosqld install --config <pathToConfigFile>/mongosqld.conf
+         systemctl start mongosql.service
+
+      To enable the service so it starts automatically at boot time, run
+      the following:
+
+      .. cssclass:: copyable-code
+      .. code-block:: sh
+
+         systemctl enable mongosql.service
 ---
 stepnum: 5
-title: Start ``mongosqld`` as a system service using a configuration file.
-ref: start-mongosqld-service
-level: 4
-source:
-  file: steps-install-bi-connector.yaml
-  ref: start-mongosqld-service
-action:
-  - heading: "Debian 7.x (Wheezy)"
-    content: |
-
-      .. cssclass:: copyable-code
-      .. code-block:: sh
-
-         mongosqld install --config {pathToConfigFile}/mongosqld.conf
-         service mongosqld start
-
-      To enable the service so it starts automatically at boot time, run
-      the following:
-
-      .. cssclass:: copyable-code
-      .. code-block:: sh
-
-         chkconfig mongosqld on
-
-  - heading: "Debian 8.1 (Jessie) and Ubuntu 14.04 (Trusty)"
-    content: |
-
-      .. cssclass:: copyable-code
-      .. code-block:: sh
-
-         mongosqld install --config {pathToConfigFile}/mongosqld.conf
-         systemctl start mongosqld.service
-
-      To enable the service so it starts automatically at boot time, run
-      the following:
-
-      .. cssclass:: copyable-code
-      .. code-block:: sh
-
-         systemctl enable mongosqld.service
----
-stepnum: 6
 ref: install-auth-plugin-debian
 level: 4
 source:
   file: steps-install-bi-connector.yaml
   ref: install-auth-plugin
 ---
-stepnum: 7
+stepnum: 6
 ref: connect-to-bi-server-debian
 level: 4
 source:

--- a/source/includes/steps-install-bi-connector-macos.yaml
+++ b/source/includes/steps-install-bi-connector-macos.yaml
@@ -36,35 +36,72 @@ source:
   ref: generate-schema
 ---
 stepnum: 4
-ref: edit-config-file-mac
+ref: start-mongosqld-mac
 level: 4
 source:
   file: steps-install-bi-connector.yaml
-  ref: edit-config-file
+  ref: start-mongosqld
+action:
+  - heading: "Start ``mongosqld`` manually:"
+    content: |
+      Using Command Line Options
+      --------------------------
+
+      .. cssclass:: copyable-code
+      .. code-block:: sh
+
+         mongosqld
+
+      For the list of command line options, see
+      :ref:`mongosqld-command-line-options`.
+
+      Using a Configuration File
+      --------------------------
+
+      Using your preferred text editor, create a ``mongosqld.conf`` file.
+      To review the configuration file options, see :ref:`Configuration
+      File <config-format>`.
+
+      .. cssclass:: copyable-code
+      .. code-block:: sh
+
+         mongosqld --config <pathToConfigFile>/mongosqld.conf
+
+  - heading: "Start ``mongosqld`` as a system service:"
+    content: |
+
+      The |bi-short| requires a configuration file with the
+      :setting:`systemLog.path` setting specified when running as a
+      system service. Using your preferred text editor, create a
+      ``mongosqld.conf`` file. To review the configuration file options,
+      see :ref:`Configuration File <config-format>`. For example:
+      
+      .. cssclass:: copyable-code
+      .. code-block:: text
+
+         systemLog:
+           path: '/logs/mongosqld.log'
+         net:
+           bindIp: "127.0.0.1"
+           port: 3307
+
+      To install and run ``mongosqld`` as a system service, run the
+      following commands:
+
+      .. cssclass:: copyable-code
+      .. code-block:: sh
+
+         mongosqld install --config <pathToConfigFile>/mongosqld.conf
+         launchctl load -w /Library/LaunchDaemons/mongosql.plist
 ---
 stepnum: 5
-ref: start-mongosqld-service-mac
-level: 4
-source:
-  file: steps-install-bi-connector.yaml
-  ref: start-mongosqld-service
-content: |
-
-  .. cssclass:: copyable-code
-  .. code-block:: sh
-
-     mongosqld install --config {pathToConfigFile}/mongosqld.conf
-     launchctl load -w /Library/LaunchDaemons/mongosqld.plist
-
----
-stepnum: 6
 ref: install-auth-plugin-mac
 level: 4
 source:
   file: steps-install-bi-connector.yaml
   ref: install-auth-plugin
 ---
-stepnum: 7
+stepnum: 6
 ref: connect-to-bi-server-mac
 level: 4
 source:

--- a/source/includes/steps-install-bi-connector-rhel.yaml
+++ b/source/includes/steps-install-bi-connector-rhel.yaml
@@ -42,62 +42,95 @@ source:
   ref: generate-schema
 ---
 stepnum: 4
-ref: edit-config-file-rhel
+ref: start-mongosqld-rhel
 level: 4
 source:
   file: steps-install-bi-connector.yaml
-  ref: edit-config-file
+  ref: start-mongosqld
+action:
+  - heading: "Start ``mongosqld`` manually:"
+    content: |
+      Using Command Line Options
+      --------------------------
+
+      .. cssclass:: copyable-code
+      .. code-block:: sh
+
+         mongosqld
+
+      For the list of command line options, see
+      :ref:`mongosqld-command-line-options`.
+
+      Using a Configuration File
+      --------------------------
+
+      Using your preferred text editor, create a ``mongosqld.conf`` file.
+      To review the configuration file options, see :ref:`Configuration
+      File <config-format>`.
+
+      .. cssclass:: copyable-code
+      .. code-block:: sh
+
+         mongosqld --config <pathToConfigFile>/mongosqld.conf
+
+  - heading: "Start ``mongosqld`` as a system service:"
+    content: |
+      The |bi-short| requires a configuration file with the
+      :setting:`systemLog.path` setting specified when running as a
+      system service. Using your preferred text editor, create a
+      ``mongosqld.conf`` file. To review the configuration file options,
+      see :ref:`Configuration File <config-format>`. For example:
+      
+      .. cssclass:: copyable-code
+      .. code-block:: text
+
+         systemLog:
+           path: '/logs/mongosqld.log'
+         net:
+           bindIp: "127.0.0.1"
+           port: 3307
+
+      RHEL 6.x / CentOS 6.x and SUSE 11:
+      ----------------------------------
+      .. cssclass:: copyable-code
+      .. code-block:: sh
+
+         mongosqld install --config <pathToConfigFile>/mongosqld.conf
+         service mongosql start
+
+      To enable the service so it starts automatically at boot time, run
+      the following:
+
+      .. cssclass:: copyable-code
+      .. code-block:: sh
+
+         chkconfig mongosql on
+
+      RHEL 7.x / CentOS 7.x and SUSE 12:
+      ----------------------------------
+
+      .. cssclass:: copyable-code
+      .. code-block:: sh
+
+         mongosqld install --config <pathToConfigFile>/mongosqld.conf
+         systemctl start mongosql.service
+
+      To enable the service so it starts automatically at boot time, run
+      the following:
+
+      .. cssclass:: copyable-code
+      .. code-block:: sh
+
+         systemctl enable mongosql.service
 ---
 stepnum: 5
-title: Start ``mongosqld`` as a system service using a configuration file.
-ref: start-mongosqld-service-rhel
-level: 4
-source:
-  file: steps-install-bi-connector.yaml
-  ref: start-mongosqld-service
-action:
-  - heading: "RHEL 6.x / CentOS 6.x and SUSE 11:"
-    content: |
-
-      .. cssclass:: copyable-code
-      .. code-block:: sh
-
-         mongosqld install --config {pathToConfigFile}/mongosqld.conf
-         service mongosqld start
-
-      To enable the service so it starts automatically at boot time, run
-      the following:
-
-      .. cssclass:: copyable-code
-      .. code-block:: sh
-
-         chkconfig mongosqld on
-
-  - heading: "RHEL 7.x / CentOS 7.x and SUSE 12:"
-    content: |
-
-      .. cssclass:: copyable-code
-      .. code-block:: sh
-
-         mongosqld install --config {pathToConfigFile}/mongosqld.conf
-         systemctl start mongosqld.service
-
-      To enable the service so it starts automatically at boot time, run
-      the following:
-
-      .. cssclass:: copyable-code
-      .. code-block:: sh
-
-         systemctl enable mongosqld.service
----
-stepnum: 6
 ref: install-auth-plugin-rhel
 level: 4
 source:
   file: steps-install-bi-connector.yaml
   ref: install-auth-plugin
 ---
-stepnum: 7
+stepnum: 6
 ref: connect-to-bi-server-rhel
 level: 4
 source:

--- a/source/includes/steps-install-bi-connector-windows.yaml
+++ b/source/includes/steps-install-bi-connector-windows.yaml
@@ -23,56 +23,114 @@ source:
   ref: generate-schema
 action:
   - heading: "Authentication not enabled:"
-    language: sh
+    language: ps1
     copyable: true
     code: |
-      "C:\Program Files\MongoDB\Connector for BI\{version}\bin\mongodrdl.exe" --host {your.mongohost.com} `
-                  --db dbname `
+      "C:\Program Files\MongoDB\Connector for BI\2.4\bin\mongodrdl.exe" --host <your.mongohost.com> `
+                  --db <dbname> `
                   [--collection collname] `
                   --out schema.drdl
   - heading: "Authentication enabled:"
-    language: sh
+    language: ps1
     copyable: true
     code: |
-      "C:\Program Files\MongoDB\Connector for BI\{version}\bin\mongodrdl.exe" --host {your.mongohost.com} `
-                  --db dbname `
+      "C:\Program Files\MongoDB\Connector for BI\2.4\bin\mongodrdl.exe" --host <your.mongohost.com> `
+                  --db <dbname> `
                   [--collection collname] `
                   --out schema.drdl  `
-                  --username {username} `
-                  --password {password} `
-                  --authenticationDatabase {dbname}
+                  --username <username> `
+                  --password <password> `
+                  --authenticationDatabase <dbname>
 ---
 stepnum: 4
-ref: edit-config-file-windows
+ref: start-mongosqld-windows
 level: 4
 source:
   file: steps-install-bi-connector.yaml
-  ref: edit-config-file
+  ref: start-mongosqld
+action:
+  - heading: "Start ``mongosqld`` manually:"
+    content: |
+      Using Command Line Options
+      --------------------------
+
+      .. cssclass:: copyable-code
+      .. code-block:: ps1
+
+         "C:\Program Files\MongoDB\Connector for BI\2.4\bin\mongosqld.exe"
+
+      For the list of command line options, see
+      :ref:`mongosqld-command-line-options`.
+
+      Using a Configuration File
+      --------------------------
+
+      Using your preferred text editor, create a ``mongosqld.conf`` file.
+      To review the configuration file options, see :ref:`Configuration
+      File <config-format>`.
+
+      .. cssclass:: copyable-code
+      .. code-block:: ps1
+
+         "C:\Program Files\MongoDB\Connector for BI\2.4\bin\mongosqld.exe" --config <pathToConfigFile>\mongosqld.conf
+
+      .. note::
+
+         All the file paths in your configuration file must be
+         absolute and wrapped in single quotes. For example:
+
+         .. code-block:: text
+
+            systemLog:
+              path: 'C:\logs\mongosqld.log'
+
+  - heading: "Start ``mongosqld`` as a system service:"
+    content: |
+      The |bi-short| requires a configuration file with the
+      :setting:`systemLog.path` setting specified when running as a
+      system service. Using your preferred text editor, create a
+      ``mongosqld.conf`` file. To review the configuration file options,
+      see :ref:`Configuration File <config-format>`. For example:
+      
+      .. cssclass:: copyable-code
+      .. code-block:: text
+
+         systemLog:
+           path: 'C:\logs\mongosqld.log'
+         net:
+           bindIp: "127.0.0.1"
+           port: 3307
+
+      .. note::
+
+         All the file paths in your configuration file must be
+         absolute and wrapped in single quotes. For example:
+
+         .. code-block:: text
+
+            systemLog:
+              path: 'C:\logs\mongosqld.log'
+
+      To install and run ``mongosqld`` as a system service, run the
+      following commands:
+
+      .. cssclass:: copyable-code
+      .. code-block:: ps1
+
+         "C:\Program Files\MongoDB\Connector for BI\2.4\bin\mongosqld.exe" install --config <pathToConfigFile>\mongosqld.conf
+         net start mongosql
+
+      Windows returns ``mongosql service installed`` if your installation
+      succeeded.
 ---
 stepnum: 5
-ref: start-mongosqld-service-windows
-level: 4
-source:
-  file: steps-install-bi-connector.yaml
-  ref: start-mongosqld-service
-content: |
-  .. cssclass:: copyable-code
-  .. code-block:: sh
-
-     "C:\Program Files\MongoDB\Connector for BI\2.2\bin\mongosqld.exe" install --config {pathToConfigFile}\mongosqld.conf
-     net start mongosqld
-post: |
-  Windows returns ``mongosql service installed`` if your installation
-  succeeded.
----
-stepnum: 6
 ref: install-auth-plugin-windows
 level: 4
 source:
   file: steps-install-bi-connector.yaml
   ref: install-auth-plugin
 ---
-stepnum: 7
+stepnum: 6
 ref: connect-to-bi-server-windows
 level: 4
 source:

--- a/source/includes/steps-install-bi-connector.yaml
+++ b/source/includes/steps-install-bi-connector.yaml
@@ -21,7 +21,7 @@ pre: |
 
 post: |
   .. note::
-     The :option:`--host` option only accepts a hostname. You cannot
+     The :option:`--host <mongodrdl --host>` option only accepts a hostname. You cannot
      provide a :ref:`MongoDB connection string <mongodb-uri>`.
 
   You can examine the generated ``schema.drdl`` file in a text editor
@@ -34,38 +34,34 @@ action:
     language: sh
     copyable: true
     code: |
-      mongodrdl --host {your.mongohost.com} \
-                --db dbname \
+      mongodrdl --host <your.mongohost.com> \
+                --db <dbname> \
                 [--collection collname] \
                 --out schema.drdl
   - heading: "Authentication enabled:"
     language: sh
     copyable: true
     code: |
-      mongodrdl --host {your.mongohost.com} \
-                --db dbname \
+      mongodrdl --host <your.mongohost.com> \
+                --db <dbname> \
                 [--collection collname] \
                 --out schema.drdl \
-                --username {username} \
-                --password {password} \
-                --authenticationDatabase {dbname}
+                --username <username> \
+                --password <password> \
+                --authenticationDatabase <dbname>
 ---
-title: Edit your |bi-short| Configuration file.
-ref: edit-config-file
-level: 4
-content: |
-  Using your preferred text editor, create a ``mongosqld.conf`` file.
-  To review the configuration file options, see :ref:`Configuration
-  File <config-format>`.
----
-title: Start ``mongosqld`` as a system service using a configuration file.
-ref: start-mongosqld-service
+title: Start ``mongosqld``.
+ref: start-mongosqld
 level: 4
 pre: |
-  .. note::
+  You can either launch ``mongosqld`` manually from the command line or
+  configure it as a system service to run on startup. Depending on your
+  use case and deployment, start ``mongosqld`` using only one of the
+  following methods:
 
-     All the file paths in your configuration file must be
-     absolute.
+  - `Start Manually Using Command Line Options <#using-command-line-options>`__
+  - `Start Manually Using a Configuration File <#using-a-configuration-file>`__
+  - `Start as a System Service <#start-mongosqld-as-a-system-service>`__
 ---
 title: Install the Authentication Plugin
 level: 4

--- a/source/tutorial/install-bi-connector-debian.txt
+++ b/source/tutorial/install-bi-connector-debian.txt
@@ -36,5 +36,3 @@ Install the |bi-short|
 ----------------------
 
 .. include:: /includes/steps/install-bi-connector-debian.rst
-
-.. include:: /includes/change-schema-file.rst

--- a/source/tutorial/install-bi-connector-macos.txt
+++ b/source/tutorial/install-bi-connector-macos.txt
@@ -33,5 +33,3 @@ Install the |bi-short|
 ----------------------
 
 .. include:: /includes/steps/install-bi-connector-macos.rst
-
-.. include:: /includes/change-schema-file.rst

--- a/source/tutorial/install-bi-connector-rhel.txt
+++ b/source/tutorial/install-bi-connector-rhel.txt
@@ -36,5 +36,3 @@ Install the |bi-short|
 ----------------------
 
 .. include:: /includes/steps/install-bi-connector-rhel.rst
-
-.. include:: /includes/change-schema-file.rst

--- a/source/tutorial/install-bi-connector-windows.txt
+++ b/source/tutorial/install-bi-connector-windows.txt
@@ -27,5 +27,3 @@ Install the |bi-short|
 ----------------------
 
 .. include:: /includes/steps/install-bi-connector-windows.rst
-
-.. include:: /includes/change-schema-file.rst


### PR DESCRIPTION
…g as a service is option and mongosqld can be launched manually. Make config file optional by including the option for it when launching mongosqld.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs-bi-connector/92)
<!-- Reviewable:end -->
