### PR TITLE
DOCSP-2217 - No longer supporting SUSE11 and Debian 7.1

### DIFF
--- a/source/installation.txt
+++ b/source/installation.txt
@@ -49,16 +49,16 @@ s390x systems running Red Hat Enterprise Linux 7.2+; and the following
      - 7.0 or later
 
    * - Debian (64-bit)
-     - 7.1 or later ("Wheezy")
      - 8.1 or later ("Jessie")
+     -
 
    * - Ubuntu (64-bit)
      - 14.04 ("Trusty")
      -
 
    * - SUSE Enterprise Linux (64-bit)
-     - 11
      - 12
+     -
 
 .. class:: hidden
 

--- a/source/launch.txt
+++ b/source/launch.txt
@@ -59,19 +59,15 @@ Run BI Connector via MongoDB Atlas
 
    tabs:
      - id: windows
-       name: Windows
        content: |
 
      - id: macos
-       name: macOS
        content: |
 
      - id: debian
-       name: Debian
        content: |
 
      - id: rhel
-       name: RHEL
        content: |
 
 You can use command line options to specify collections and databases
@@ -100,7 +96,6 @@ For more information about ``.drdl`` files and the
 
    tabs:
      - id: windows
-       name: Windows
        content: |
          The following example uses the :option:`--sampleNamespaces <mongosqld
          --sampleNamespaces>` option to specify the ``books`` collection in the
@@ -112,7 +107,6 @@ For more information about ``.drdl`` files and the
             "C:\Program Files\MongoDB\Connector for BI\2.4\bin\mongosqld.exe" --sampleNamespaces test.books
 
      - id: macos
-       name: MacOS
        content: |
          The following example uses the :option:`--sampleNamespaces <mongosqld
          --sampleNamespaces>` option to specify the ``books`` collection in the
@@ -124,7 +118,6 @@ For more information about ``.drdl`` files and the
             mongosqld --sampleNamespaces test.books
 
      - id: debian
-       name: Debian
        content: |
          The following example uses the :option:`--sampleNamespaces <mongosqld
          --sampleNamespaces>` option to specify the ``books`` collection in the
@@ -136,7 +129,6 @@ For more information about ``.drdl`` files and the
             mongosqld --sampleNamespaces test.books
 
      - id: rhel
-       name: RHEL
        content: |
          The following example uses the :option:`--sampleNamespaces <mongosqld
          --sampleNamespaces>` option to specify the ``books`` collection in the
@@ -162,19 +154,15 @@ For more information about ``.drdl`` files and the
 
    tabs:
      - id: windows
-       name: Windows
        content: |
 
      - id: macos
-       name: MacOS
        content: |
 
      - id: debian
-       name: Debian
        content: |
 
      - id: rhel
-       name: RHEL
        content: |
 
 You can use a :ref:`configuration file <config-format>` to hold all your
@@ -188,7 +176,6 @@ configuration file.
 
    tabs:
      - id: windows
-       name: Windows
        content: |
          .. cssclass:: copyable-code
          .. code-block:: ps1
@@ -196,7 +183,6 @@ configuration file.
             "C:\Program Files\MongoDB\Connector for BI\2.4\bin\mongosqld.exe" --config <pathToConfigFile>\mongosqld.conf
 
      - id: macos
-       name: MacOS
        content: |
          .. cssclass:: copyable-code
          .. code-block:: ps1
@@ -204,7 +190,6 @@ configuration file.
             mongosqld --config <pathToConfigFile>/mongosqld.conf
 
      - id: debian
-       name: Debian
        content: |
          .. cssclass:: copyable-code
          .. code-block:: ps1
@@ -212,7 +197,6 @@ configuration file.
             mongosqld --config <pathToConfigFile>/mongosqld.conf
 
      - id: rhel
-       name: RHEL
        content: |
          .. cssclass:: copyable-code
          .. code-block:: ps1
@@ -230,19 +214,15 @@ configuration file.
 
    tabs:
      - id: windows
-       name: Windows
        content: |
 
      - id: macos
-       name: MacOS
        content: |
 
      - id: debian
-       name: Debian
        content: |
 
      - id: rhel
-       name: RHEL
        content: |
 
 |bi-short| requires a configuration file with the
@@ -257,7 +237,6 @@ see :ref:`Configuration File <config-format>`. For example:
 
    tabs:
      - id: windows
-       name: Windows
        content: |
          .. code-block:: text
 
@@ -290,7 +269,6 @@ see :ref:`Configuration File <config-format>`. For example:
          succeeded.
 
      - id: macos
-       name: MacOS
        content: |
          .. code-block:: text
 
@@ -309,7 +287,6 @@ see :ref:`Configuration File <config-format>`. For example:
             launchctl load -w /Library/LaunchDaemons/mongosql.plist
 
      - id: debian
-       name: Debian
        content: |
 
          .. code-block:: text
@@ -320,23 +297,8 @@ see :ref:`Configuration File <config-format>`. For example:
               bindIp: '127.0.0.1'
               port: 3307
 
-         Debian 7.x (Wheezy)
-         ~~~~~~~~~~~~~~~~~~~
-
-         .. code-block:: sh
-
-            mongosqld install --config <pathToConfigFile>/mongosqld.conf
-            service mongosql start
-
-         To enable the service so it starts automatically at boot time, run
-         the following:
-
-         .. code-block:: sh
-
-            chkconfig mongosql on
-
-         Debian 8.1 (Jessie) and Ubuntu 14.04 (Trusty)
-         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         To install and run ``mongosqld`` as a system service, run the
+         following commands:
 
          .. code-block:: sh
 
@@ -351,7 +313,6 @@ see :ref:`Configuration File <config-format>`. For example:
             systemctl enable mongosql.service
 
      - id: rhel
-       name: RHEL
        content: |
          .. code-block:: text
 
@@ -361,8 +322,11 @@ see :ref:`Configuration File <config-format>`. For example:
               bindIp: '127.0.0.1'
               port: 3307
 
-         RHEL 6.x / CentOS 6.x and SUSE 11
-         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         RHEL 6.x / CentOS 6.x
+         ~~~~~~~~~~~~~~~~~~~~~
+
+         To install and run ``mongosqld`` as a system service, run the
+         following commands:
 
          .. code-block:: sh
 
@@ -379,6 +343,9 @@ see :ref:`Configuration File <config-format>`. For example:
 
          RHEL 7.x / CentOS 7.x and SUSE 12
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+         To install and run ``mongosqld`` as a system service, run the
+         following commands:
 
          .. code-block:: sh
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs-bi-connector/126)
<!-- Reviewable:end -->
