### PR TITLE
DOCSP-2443 - Pre-ODBC driver fixes for Tableau docs: Add ODBC Manager…

### DIFF
--- a/source/includes/client-prereqs.rst
+++ b/source/includes/client-prereqs.rst
@@ -1,12 +1,29 @@
 Prerequisites
 -------------
 
-Before using Tableau with |bi-short| you should have:
+.. tabs-platforms::
 
-- A running :manual:`mongod </reference/program/mongod/>` instance or `Atlas
-  deployment <https://docs.atlas.mongodb.com/>`_
-- A running :binary:`~bin.mongosqld` instance
-- The `MySQL Connector/ODBC driver (Version 5.3.10)
-  <https://dev.mysql.com/downloads/connector/odbc/5.3.html>`_
+   tabs:
 
-  .. include:: /includes/fact-mysql-odbc-version-reqs.rst
+     - id: windows
+       content: |
+         Before using Tableau with |bi-short| you should have:
+
+         - A running :manual:`mongod </reference/program/mongod/>` instance or `Atlas
+           deployment <https://docs.atlas.mongodb.com/>`_
+         - A running :binary:`~bin.mongosqld` instance
+         - The `MySQL Connector/ODBC driver (Version 5.3.10)
+           <https://dev.mysql.com/downloads/connector/odbc/5.3.html>`_
+
+     - id: macos
+       content: |
+         Before using Tableau with |bi-short| you should have:
+
+         - A running :manual:`mongod </reference/program/mongod/>` instance or `Atlas
+           deployment <https://docs.atlas.mongodb.com/>`_
+         - A running :binary:`~bin.mongosqld` instance
+         - `ODBC Manager <http://www.odbcmanager.net/>`_ installed
+         - The `MySQL Connector/ODBC driver (Version 5.3.10)
+           <https://dev.mysql.com/downloads/connector/odbc/5.3.html>`_
+
+.. include:: /includes/fact-mysql-odbc-version-reqs.rst

--- a/source/includes/steps-connect-tableau-mongosql-plugin.yaml
+++ b/source/includes/steps-connect-tableau-mongosql-plugin.yaml
@@ -39,9 +39,6 @@ content: |
                  ``mongosql_auth`` plugin to the
                  ``/Users/{user}/Downloads/`` directory.
 
-                 The plugin does not require MySQL or the MySQL ODBC
-                 Connector to be installed.
-
 ---
 title: Create a `MySQL configuration file <https://dev.mysql.com/doc/refman/5.7/en/option-files.html>`_. (macOS only)
 ref: create-my-cnf


### PR DESCRIPTION
… as prereq and remove confusing auth plugin info.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs-bi-connector/137)
<!-- Reviewable:end -->
