### PR TITLE
(DOCSP-2437): Added Kerberos options.

### DIFF
--- a/source/includes/options-mongosqld.yaml
+++ b/source/includes/options-mongosqld.yaml
@@ -679,7 +679,10 @@ args: <hostname>
 description: |
   .. versionadded:: 2.5
 
-  Hostname that serves Kerberos.
+  An :abbr:`FQDN (fully qualified domain name)` for the purpose of
+  configuring Kerberos authentication. The Kerberos hostname overrides
+  the hostname only for the configuration of Kerberos.
+
 optional: true
 default: First IP address for :setting:`net.bindIp`.
 ---
@@ -690,7 +693,11 @@ args: <service-name>
 description: |
   .. versionadded:: 2.5
 
-  Name of the system service which runs the Kerberized :binary:`~bin.mongosqld`.
+  Registered name of the service using Kerberos. This option allows 
+  you to override the default Kerberos service name component of the 
+  Kerberos :abbr:`SPN (service principal name)`, on a per-instance 
+  basis. If unspecified, the default value is used.
+
 optional: true
 default: mongosql
 ---
@@ -701,7 +708,10 @@ args: <service-name>
 description: |
   .. versionadded:: 2.5
 
-  Name of the system service which runs the Kerberized ``mongod``.
+  Set the Kerberos :abbr:`SPN (service principal name)` when connecting
+  to Kerberized MongoDB instances. This value must match the service
+  name set on MongoDB instances.
+
 optional: true
 default: mongodb
 ...

--- a/source/reference/mongosqld.txt
+++ b/source/reference/mongosqld.txt
@@ -466,7 +466,7 @@ Security Options
      enabled: <boolean>
      defaultMechanism: <string>
      defaultSource: <string>
-     gssapi.
+     gssapi:
        hostname: <string>
        serviceName: <string>
 


### PR DESCRIPTION
@rychipman : I have provided all of the options. I still have a question posted to you in JIRA for DOCSP-2437 about where in the conf file these values would go. Please have a look. 

- [Kerberos Options](https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/anthonysansone/DOCSP-2437/reference/mongosqld.html#kerberos-options)
- [Kerberos in Security Options for Conf file](https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/anthonysansone/DOCSP-2437/reference/mongosqld.html#security-options)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs-bi-connector/140)
<!-- Reviewable:end -->
