### PR TITLE
DOCSP-3526: [BIC] Support GROUP_CONCAT aggregate function

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -125,7 +125,6 @@ in the :doc:`Quick Start Guide </local-quickstart>`.
       /authentication
       /schema-configuration
       Components </components>
-      /supported-operations
       /reference
       FAQ </faq>
       Release Notes </release-notes>

--- a/source/reference.txt
+++ b/source/reference.txt
@@ -22,3 +22,5 @@ Reference
       /reference/log-messages
       /reference/type-conversion
       /reference/user-authorization
+      /supported-operations
+	  

--- a/source/supported-operations.txt
+++ b/source/supported-operations.txt
@@ -484,7 +484,7 @@ Information Functions
    * - ``SUM()``
      - Return the sum
    * - ``GROUP_CONCAT()``
-     - Return a concatenated string, non-NULL values only
+     - Return a concatenated string, non-``NULL`` values only
 
 Utility Statements
 ------------------

--- a/source/supported-operations.txt
+++ b/source/supported-operations.txt
@@ -483,7 +483,8 @@ Information Functions
      - Return the sample standard deviation
    * - ``SUM()``
      - Return the sum
-
+   * - ``GROUP_CONCAT()``
+     - Return a concatenated string, non-NULL values only
 
 Utility Statements
 ------------------


### PR DESCRIPTION
Staged: [GROUP BY (Aggregate) Functions](https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/steverenaker/DOCSP-3526/supported-operations.html#group-by-aggregate-functions)