### PR TITLE
(DOCS-12418): Add sudo to system service commands.

### DIFF
--- a/source/launch.txt
+++ b/source/launch.txt
@@ -299,11 +299,11 @@ see :ref:`Configuration File <config-format>`. For example:
 
          .. code-block:: sh
 
-            mongosqld install --config <pathToConfigFile>/mongosqld.conf
-            systemctl start mongosql.service
+            sudo mongosqld install --config <pathToConfigFile>/mongosqld.conf
+            sudo systemctl start mongosql.service
 
-         To enable the service so it starts automatically at boot time, run
-         the following:
+         To enable the service so it starts automatically at boot time,
+         run the following:
 
          .. code-block:: sh
 
@@ -327,16 +327,15 @@ see :ref:`Configuration File <config-format>`. For example:
 
          .. code-block:: sh
 
-            mongosqld install --config <pathToConfigFile>/mongosqld.conf
-            service mongosql start
+            sudo mongosqld install --config <pathToConfigFile>/mongosqld.conf
+            sudo service mongosql start
 
-         To enable the service so it starts automatically at boot time, run
-         the following:
+         To enable the service so it starts automatically at boot time,
+         run the following:
 
-         .. cssclass:: copyable-code
          .. code-block:: sh
 
-            chkconfig mongosql on
+            sudo chkconfig mongosql on
 
          RHEL 7.x / CentOS 7.x and SUSE 12
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -346,15 +345,15 @@ see :ref:`Configuration File <config-format>`. For example:
 
          .. code-block:: sh
 
-            mongosqld install --config <pathToConfigFile>/mongosqld.conf
-            systemctl start mongosql.service
+            sudo mongosqld install --config <pathToConfigFile>/mongosqld.conf
+            sudo systemctl start mongosql.service
 
-         To enable the service so it starts automatically at boot time, run
-         the following:
+         To enable the service so it starts automatically at boot time,
+         run the following:
 
          .. code-block:: sh
 
-            systemctl enable mongosql.service
+            sudo systemctl enable mongosql.service
 
 Next Steps
 ----------


### PR DESCRIPTION
@nlarew : This adds `sudo` to the Debian and RHEL tabs of the [Install mongosqld as a System Service](https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/anthonysansone/DOCS-12418/launch.html#install-mongosqld-as-a-system-service) section. 