### PR TITLE
(DOCSP-4787): Added Kerberos for Linux caveats.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -87,6 +87,7 @@ rst_epilog = '\n'.join([
     '.. |kdc| replace:: :abbr:`KDC (Key Distribution Center)`',
     '.. |adc| replace:: :abbr:`ADC (Active Directory Controller)`',
     '.. |spn| replace:: :abbr:`SPN (Service Principal Name)`',
+    '.. |upn| replace:: :abbr:`UPN (User Principal Name)`',
     '.. |sasl| replace:: :abbr:`SASL (Simple Authentication and Security Layer)`',
     '.. |iana| replace:: :abbr:`IANA (Internet Assigned Numbers Authority)`',
     '.. |scram| replace:: :abbr:`SCRAM (Salted Challenge Response Authentication Mechanism)`'

--- a/conf.py
+++ b/conf.py
@@ -106,7 +106,8 @@ source_constants = {
 extlinks = {
     'issue': ('https://jira.mongodb.org/browse/%s', '' ),
     'manual': ('http://docs.mongodb.com/manual%s', ''),
-    'v3.6': ('https://docs.mongodb.com/v3.6%s', '')
+    'v3.6': ('https://docs.mongodb.com/v3.6%s', ''),
+    'website': ('https://www.mongodb.com%s?jmp=docs', ''),
 }
 
 intersphinx_mapping = {}

--- a/source/tutorial/kerberos.txt
+++ b/source/tutorial/kerberos.txt
@@ -32,11 +32,11 @@ Kerberos authentication on either Windows or macOS.
 
          .. important::
 
-            The domain part of any username must be written 
-            in all capital letters. This part of the username 
-            corresponds to a Kerberos realm or Active 
-            Directory domain. It is case sensitive.
-            
+            The domain part of any username must be written
+            in all capital letters. This part of the username
+            corresponds to a Kerberos realm or Active
+            Directory domain. It *is* case sensitive.
+
          Active Directory Configuration
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -49,9 +49,11 @@ Kerberos authentication on either Windows or macOS.
 
          .. example::
 
+            Assuming this configuration:
+
             - Your name is ``Grace Smith``.
-            - Your Windows domain is named ``EXAMPLE.COM``. 
-            - You are running your BI tool on a Windows host 
+            - Your Windows domain is named ``EXAMPLE.COM``.
+            - You are running your BI tool on a Windows host
               named ``BI.EXAMPLE.COM``.
 
             In Active Directory, you create three users:
@@ -68,11 +70,23 @@ Kerberos authentication on either Windows or macOS.
                setspn.exe -A mongosql/BI.EXAMPLE.COM mongosql
 
             Open the `Active Directory Administrative Center <https://docs.microsoft.com/en-us/windows-server/identity/ad-ds/get-started/adac/active-directory-administrative-center>`__
-            and double-click on your MongoDB service user 
+            and double-click on your MongoDB service user
             (``mongodb``).
 
-            Set the ``mongosql`` user to delegate for the 
+            Set the ``mongosql`` user to delegate for the
             ``mongodb`` user from the ``BI.EXAMPLE.COM`` host.
+
+
+            .. admonition:: Linux Schema User Authenticating to ADC
+               :class: note
+
+               If you are authenticating a user from a Linux host, the
+               user must authenticate using Kerberos. On the Linux
+               client, this requires:
+
+               - Creating a |upn| for the schema user.
+               - Setting the `KRB5_CLIENT_KTNAME <https://web.mit.edu/kerberos/krb5-latest/doc/basic/keytab_def.html#default-client-keytab>`__
+                 environment variable to this user's keytab.
 
          MongoDB Configuration
          ~~~~~~~~~~~~~~~~~~~~~
@@ -93,11 +107,23 @@ Kerberos authentication on either Windows or macOS.
            :xml:`<mono><link target="https://docs.mongodb.com/manual/reference/configuration-options/#setparameter-option">setParameter</link></mono>`,
            and :xml:`<mono><link target="https://docs.mongodb.com/manual/reference/parameters/#param.authenticationMechanisms">authenticationMechanisms</link></mono>`.
 
-         - Run ``mongod`` as the MongoDB Windows user you 
+         - Run ``mongod`` as the MongoDB Windows user you
            created in Active Directory.
-         - :manual:`Create a user </reference/method/db.createUser>` on your MongoDB database with the 
-           :ref:`appropriate roles <cached-sampling-user-permissions>` 
+         - :manual:`Create a user </reference/method/db.createUser>` on your MongoDB database with the
+           :ref:`appropriate roles <cached-sampling-user-permissions>`
            to sample data.
+
+           .. admonition:: Linux Schema User Authenticating to ADC
+              :class: note
+
+              If you are authenticating a user from a Linux host, the 
+              user must authenticate using Kerberos. On the
+              ``mongod``, this requires:
+
+              - Setting :setting:`mongodb.net.auth.username` to the
+                schema user's |upn|.
+              - Setting :setting:`mongodb.net.auth.password` to no
+                value.
 
          BI Connector Configuration
          ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -144,7 +170,7 @@ Kerberos authentication on either Windows or macOS.
                    password: <database password>
                    source: "$external"
                    mechanism: "GSSAPI"
-           
+
            For more information, see:
 
            - :setting:`mongodb.net.uri`
@@ -225,19 +251,19 @@ Kerberos authentication on either Windows or macOS.
                      displayName: "MongoDB BI Connector"
 
             - Open :guilabel:`Services`.
-            - Set MongoDB to 
-              :guilabel:`Log on as: This account:` 
-              ``mongodb@EXAMPLE.COM`` 
-            - Set |bi| to 
-              :guilabel:`Log on as: This account:` 
+            - Set MongoDB to
+              :guilabel:`Log on as: This account:`
+              ``mongodb@EXAMPLE.COM``
+            - Set |bi| to
+              :guilabel:`Log on as: This account:`
               ``mongosql@EXAMPLE.COM``
             - Start the MongoDB and |bi| services.
 
          .. seealso::
 
-            To learn how to configure Active Directory to 
+            To learn how to configure Active Directory to
             manage your MongoDB instance, see
-            :manual:`Configure MongoDB with Kerberos Authentication and Active Directory Authorization 
+            :manual:`Configure MongoDB with Kerberos Authentication and Active Directory Authorization
             </tutorial/kerberos-auth-activedirectory-authz/>`.
 
      - id: macos
@@ -262,7 +288,7 @@ Kerberos authentication on either Windows or macOS.
               setParameter:
                 authenticationMechanisms: "GSSAPI"
 
-         - `Create a keytab file`_ on the |kdc| that has the 
+         - `Create a keytab file`_ on the |kdc| that has the
            needed Kerberos :ref:`service principals <kerberos-service-principal>`
            for ``mongosql`` and ``mongosql2``.
 
@@ -277,20 +303,20 @@ Kerberos authentication on either Windows or macOS.
 
          - Copy the ``keytab`` file you created for your MongoDB
            deployment to the same host that serves the |bi-short|.
-         - If your keytab does not use the default name 
+         - If your keytab does not use the default name
            (``krb5.keytab``), you must set the
            `KRB5_KTNAME <https://web.mit.edu/kerberos/krb5-latest/doc/basic/keytab_def.html>`_
            environment variable.
 
            .. note::
 
-              The Kerberos implementation on macOS, 
-              `Heimdal`_, does not support the 
+              The Kerberos implementation on macOS,
+              `Heimdal`_, does not support the
               ``default_keytab_name`` configuration
-              setting, like MIT Kerberos does. You must set 
+              setting, like MIT Kerberos does. You must set
               the ``KRB5_KTNAME`` environment variable.
 
-         - If your Kerberos configuration file does not use 
+         - If your Kerberos configuration file does not use
            the default name (``krb5.conf``), you must set the
            `KRB5_CONFIG <https://web.mit.edu/kerberos/krb5-devel/doc/admin/conf_files/krb5_conf.html>`_
            environment variable. (Heimdal also supports
@@ -334,7 +360,7 @@ Kerberos authentication on either Windows or macOS.
                    password: <database password>
                    source: "$external"
                    mechanism: "GSSAPI"
-           
+          
            For more information, see:
 
            - :setting:`mongodb.net.uri`

--- a/source/tutorial/kerberos.txt
+++ b/source/tutorial/kerberos.txt
@@ -20,9 +20,14 @@ Configure Kerberos for |bi-short|
 .. versionadded:: 2.5
 
 The |bi| supports Kerberos authentication for connecting BI tools and
-for the |bi-short|'s admin user authenticating with MongoDB. The
-following section guides you through configuring the |bi-short| to use
-Kerberos authentication on either Windows or macOS.
+for the |bi-short|'s admin user authenticating with MongoDB.
+
+The following section guides you through configuring the |bi-short| to use Kerberos authentication with two of the most common use cases:
+
+- Windows/Linux client machines authenticating to Active Directory
+- macOS client machine authenticating to Linux |kdc|
+
+If you have another use case, please contact :website:`MongoDB Support </support/get-started>` for assistance.
 
 .. tabs-platforms::
 
@@ -66,8 +71,13 @@ Kerberos authentication on either Windows or macOS.
 
             .. code-block:: powershell
 
-               setspn.exe -A mongodb/BI.EXAMPLE.COM mongodb
-               setspn.exe -A mongosql/BI.EXAMPLE.COM mongosql
+               setspn.exe -S mongodb/BI.EXAMPLE.COM mongodb
+               setspn.exe -S mongosql/BI.EXAMPLE.COM mongosql
+
+            .. note::
+
+               The names can be anything you choose as long as you use
+               them consistently throughout this setup.
 
             Open the `Active Directory Administrative Center <https://docs.microsoft.com/en-us/windows-server/identity/ad-ds/get-started/adac/active-directory-administrative-center>`__
             and double-click on your MongoDB service user
@@ -80,9 +90,10 @@ Kerberos authentication on either Windows or macOS.
             .. admonition:: Linux Schema User Authenticating to ADC
                :class: note
 
-               If you are authenticating a user from a Linux host, the
-               user must authenticate using Kerberos. On the Linux
-               client, this requires:
+               If you are authenticating a user from a Linux host and
+               the schema user is using a keytab file instead of a
+               password, the following is required in addition to
+               creating the user in MongoDB:
 
                - Creating a |upn| for the schema user.
                - Setting the `KRB5_CLIENT_KTNAME <https://web.mit.edu/kerberos/krb5-latest/doc/basic/keytab_def.html#default-client-keytab>`__
@@ -109,21 +120,12 @@ Kerberos authentication on either Windows or macOS.
 
          - Run ``mongod`` as the MongoDB Windows user you
            created in Active Directory.
-         - :manual:`Create a user </reference/method/db.createUser>` on your MongoDB database with the
+         - :manual:`Create a user </reference/method/db.createUser>`
+           on your MongoDB database with the
            :ref:`appropriate roles <cached-sampling-user-permissions>`
            to sample data.
 
-           .. admonition:: Linux Schema User Authenticating to ADC
-              :class: note
 
-              If you are authenticating a user from a Linux host, the 
-              user must authenticate using Kerberos. On the
-              ``mongod``, this requires:
-
-              - Setting :setting:`mongodb.net.auth.username` to the
-                schema user's |upn|.
-              - Setting :setting:`mongodb.net.auth.password` to no
-                value.
 
          BI Connector Configuration
          ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -258,6 +260,18 @@ Kerberos authentication on either Windows or macOS.
               :guilabel:`Log on as: This account:`
               ``mongosql@EXAMPLE.COM``
             - Start the MongoDB and |bi| services.
+
+         .. admonition:: Linux Schema User Authenticating to ADC
+            :class: note
+
+            If you are authenticating a user from a Linux host and
+            your schema user is going to use a username and password,
+            the following is required:
+
+            - Setting :setting:`mongodb.net.auth.username` to the
+              schema user's |upn|.
+            - Setting :setting:`mongodb.net.auth.password` to no
+              value.
 
          .. seealso::
 


### PR DESCRIPTION
Added notes to Windows setup for Linux clients. [Staged](https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/anthonysansone/DOCSP-4787/tutorial/kerberos.html)