### PR TITLE
DOCSP-5779 - Update mongosqld command line options and config file settings.

### DIFF
--- a/source/includes/fact-sampleRefresh.rst
+++ b/source/includes/fact-sampleRefresh.rst
@@ -1,6 +1,6 @@
 By default, :binary:`~bin.mongosqld` does not automatically resample
 data after generating the schema. Specify the
-:option:`--sampleRefreshIntervalSecs <mongosqld
---sampleRefreshIntervalSecs>` option to direct
+:option:`--schemaRefreshIntervalSecs <mongosqld
+--schemaRefreshIntervalSecs>` option to direct
 :binary:`~bin.mongosqld` to automatically resample the data and
 regenerate the schema on a fixed schedule.

--- a/source/includes/fact-samplemode-write-permission.rst
+++ b/source/includes/fact-samplemode-write-permission.rst
@@ -2,7 +2,7 @@
 
    If ``mongosqld`` has :option:`authentication <mongosqld --auth>`
    enabled, the authenticated user must have the ``write``
-   privilege on the specified :option:`--sampleSource <mongosqld
-   --sampleSource>` database. See :manual:`Built-In Roles
+   privilege on the specified :option:`--schemaSource <mongosqld
+   --schemaSource>` database. See :manual:`Built-In Roles
    </reference/built-in-roles/>` for more information about the
    ``readWrite`` role.

--- a/source/includes/fact-samplemode-write-permission.rst
+++ b/source/includes/fact-samplemode-write-permission.rst
@@ -1,7 +1,7 @@
 .. important::
 
    If ``mongosqld`` has :option:`authentication <mongosqld --auth>`
-   enabled, the authenticated user must have the ``write``
+   enabled, the authenticated user must have the write
    privilege on the specified :option:`--schemaSource <mongosqld
    --schemaSource>` database. See :manual:`Built-In Roles
    </reference/built-in-roles/>` for more information about the

--- a/source/includes/options-mongosqld.yaml
+++ b/source/includes/options-mongosqld.yaml
@@ -105,18 +105,17 @@ name: schemaSource
 directive: option
 args: <db-name>
 description: |
-  .. versionchanged:: 2.11
 
-     Renamed ``--sampleSource`` to ``--schemaSource``     
+  .. versionadded:: 2.11
 
-  Required when :option:`--schemaMode <mongosqld --schemaMode>` is set
-  to ``auto``. Specifies a database to store schema information.
+  Required whenever the :option:`--schemaMode <mongosqld --schemaMode>`
+  is set. Specifies the database where the schema information is stored.
   
   .. note::
 
-     If you do not specify either a schema file with the
-     :option:`--schema` option or a database with the
-     ``--schemaSource`` option, :binary:`~bin.mongosqld` holds its
+     If you do not specify any of the :option:`--schema`,
+     :option:`--schemaMode <mongosqld --schemaMode>`, and
+     ``--schemaSource`` options, :binary:`~bin.mongosqld` holds its
      schema in memory.
 
   .. include:: /includes/sampling-ref-chart-link.rst
@@ -181,22 +180,30 @@ name: schemaMode
 directive: option
 args: <[custom|auto]>
 description: |
-  .. versionchanged:: 2.11
-
-     Renamed ``--sampleMode`` to ``--schemaMode``
+  .. versionadded:: 2.11
 
   Configures the :ref:`sampling mode <sampling-mode-chart>` of
-  :binary:`~bin.mongosqld`.
-  
-  When ``--schemaMode`` is set to ``custom``,
-  :binary:`~bin.mongosqld` can either:
+  :binary:`~bin.mongosqld`. Must be used with the
+  :option:`--schemaSource <mongosqld --schemaSource>` option.
+  The following values determine the sampling behavior:
 
-  - Sample data from the MongoDB database to generate the
-    relational schema and hold the schema in memory.
+  .. list-table::
+     :widths: 30 70
+     :header-rows: 1
 
-  - Read a stored schema from the MongoDB
-    database named in the
-    :option:`--schemaSource <mongosqld --schemaSource>` option.
+     * - Value
+       - ``--schemaMode`` Behavior
+
+     * - ``custom``
+       - :binary:`~bin.mongosqld` reads a stored
+         schema from the MongoDB database specified by the
+         :option:`--schemaSource <mongosqld --schemaSource>` option.
+
+     * - ``auto``
+       - :binary:`~bin.mongosqld`
+         samples the schema and writes the schema data to the MongoDB
+         database specified by the
+         :option:`--schemaSource <mongosqld --schemaSource>` option.
 
   When ``--schemaMode`` is set to ``auto``, :binary:`~bin.mongosqld`
   samples the schema and writes the schema data to the MongoDB
@@ -225,13 +232,6 @@ description: |
   that after the initial sampling no re-sampling occurs for the
   duration of the connection. The specified value must be a positive
   integer.
-
-  If you specify a non-zero value for ``--schemaRefreshIntervalSecs``
-  and a schema database with the :option:`--schemaSource
-  <mongosqld --schemaSource>` option,
-  you must also set the :option:`--schemaMode <mongosqld --schemaMode>`
-  option to ``auto``. Otherwise, :binary:`~bin.mongosqld` halts with
-  an error.
 
   .. include:: /includes/fact-resample-schema-data.rst
 

--- a/source/includes/options-mongosqld.yaml
+++ b/source/includes/options-mongosqld.yaml
@@ -130,11 +130,14 @@ description: |
   .. versionadded:: 2.11    
 
   Optional. The name of the schema to load from or write to
-  the :option:`--schemaSource <mongosqld --schemaSource>` database
-  depending on the value of :option:`--schemaMode <mongosqld --schemaMode>`:
+  the :option:`--schemaSource <mongosqld --schemaSource>` database.
+  Specifying schema names allows you to store multiple schemas in
+  the :option:`--schemaSource <mongosqld --schemaSource>` database.
+  The behavior depends on on the value of
+  :option:`--schemaMode <mongosqld --schemaMode>`:
 
   .. list-table::
-     :widths: 10 90
+     :widths: 30 70
      :header-rows: 1
 
      * - :option:`--schemaMode <mongosqld --schemaMode>` Value
@@ -147,7 +150,8 @@ description: |
 
      * - ``auto``
        - The name of the schema to write to the :option:`--schemaSource
-         <mongosqld --schemaSource>`
+         <mongosqld --schemaSource>` database after the |bi-short|
+         samples the schema on startup.
 
   If not specified, defaults to ``defaultSchema``.
 
@@ -182,18 +186,22 @@ description: |
      Renamed ``--sampleMode`` to ``--schemaMode``
 
   Configures the :ref:`sampling mode <sampling-mode-chart>` of
-  :binary:`~bin.mongosqld` to either:
+  :binary:`~bin.mongosqld`.
+  
+  When ``--schemaMode`` is set to ``custom``,
+  :binary:`~bin.mongosqld` can either:
 
   - Sample data from the MongoDB database to generate the
-    relational schema.
+    relational schema and hold the schema in memory.
 
-  - Sample and write schema information to the MongoDB database
-    named in the :option:`--schemaSource <mongosqld --schemaSource>`
-    option.
-
-  - Read previously sampled schema information to the MongoDB
+  - Read previously sampled schema information from the MongoDB
     database named in the
     :option:`--schemaSource <mongosqld --schemaSource>` option.
+
+  When ``--schemaMode`` is set to ``auto``, :binary:`~bin.mongosqld`
+  samples the schema and writes the schema data to the MongoDB
+  database specified by the
+  :option:`--schemaSource <mongosqld --schemaSource>` option.
 
   For more information on configuring the sample mode, see the
   :ref:`sampling-mode-chart`.

--- a/source/includes/options-mongosqld.yaml
+++ b/source/includes/options-mongosqld.yaml
@@ -101,21 +101,55 @@ description: |
   ``admin`` and ``local`` databases.
 ---
 program: mongosqld
-name: sampleSource
+name: schemaSource
 directive: option
 args: <db-name>
 description: |
-  .. versionadded:: 2.3
+  .. versionchanged:: 2.11
 
-  Required when :option:`--sampleMode <mongosqld --sampleMode>` is set
-  to write.   Specifies a database to store schema information.
+     Renamed ``--sampleSource`` to ``-schemaSource``     
+
+  Required when :option:`--schemaMode <mongosqld --schemaMode>` is set
+  to ``auto``. Specifies a database to store schema information.
   
   .. note::
 
      If you do not specify either a schema file with the
      :option:`--schema` option or a database with the
-     ``--sampleSource`` option, :binary:`~bin.mongosqld` holds its
+     ``--schemaSource`` option, :binary:`~bin.mongosqld` holds its
      schema in memory.
+
+  .. include:: /includes/sampling-ref-chart-link.rst
+---
+program: mongosqld
+name: schemaName
+directive: option
+args: <db-name>
+default: "``defaultSchema``"
+description: |
+  .. versionadded:: 2.11    
+
+  Optional. The name of the schema to load from or write to
+  the :option:`--schemaSource <mongosqld --schemaSource>` database
+  depending on the value of :option:`--schemaMode <mongosqld --schemaMode>`:
+
+  .. list-table::
+     :widths: 10 90
+     :header-rows: 1
+
+     * - :option:`--schemaMode <mongosqld --schemaMode>` Value
+       - ``--schemaName`` Behavior
+
+     * - ``custom``
+       - The name of the schema to load from the database specified
+         by the :option:`--schemaSource <mongosqld --schemaSource>`
+         option.
+
+     * - ``auto``
+       - The name of the schema to write to the :option:`--schemaSource
+         <mongosqld --schemaSource>`
+
+  If not specified, defaults to ``defaultSchema``.
 
   .. include:: /includes/sampling-ref-chart-link.rst
 
@@ -139,35 +173,44 @@ description: |
 default: 1000  
 ---
 program: mongosqld
-name: sampleMode
+name: schemaMode
 directive: option
-args: <[read|write]>
+args: <[custom|auto]>
 description: |
-  .. versionadded:: 2.3
+  .. versionchanged:: 2.11
 
-  Specifies whether :binary:`~bin.mongosqld` writes schema information
-  to the MongoDB database named in the :option:`--sampleSource
-  <mongosqld --sampleSource>` option or only reads previously sampled
-  schema information from it.
+     Renamed ``--sampleMode`` to ``--schemaMode``
 
-  If you use the :option:`--sampleSource <mongosqld --sampleSource>`
-  option to specify a database to store schema information, set
-  :option:`--sampleMode <mongosqld --sampleMode>` to ``write`` to
-  allow :binary:`~bin.mongosqld` to persist data in the specified
-  database.
-  
+  Configures the :ref:`sampling mode <sampling-mode-chart>` of
+  :binary:`~bin.mongosqld` to either:
+
+  - Sample data from the MongoDB database to generate the
+    relational schema.
+
+  - Sample and write schema information to the MongoDB database
+    named in the :option:`--schemaSource <mongosqld --schemaSource>`
+    option.
+
+  - Read previously sampled schema information to the MongoDB
+    database named in the
+    :option:`--schemaSource <mongosqld --schemaSource>` option.
+
+  For more information on configuring the sample mode, see the
+  :ref:`sampling-mode-chart`.
+
   .. include:: /includes/fact-samplemode-write-permission.rst
 
-  .. include:: /includes/sampling-ref-chart-link.rst
-
-default: read
+default: "``custom``"
 ---
 program: mongosqld
-name: sampleRefreshIntervalSecs
+name: schemaRefreshIntervalSecs
 directive: option
 args: <number>
 description: |
-  .. versionadded:: 2.3
+  .. versionchanged:: 2.11
+
+     Renamed ``--sampleRefreshIntervalSecs`` to
+     ``--schemaRefreshIntervalSecs``
 
   The interval in seconds at which :binary:`~bin.mongosqld` re-samples
   data to create its schema. The default value is ``0``, which means
@@ -175,11 +218,11 @@ description: |
   duration of the connection. The specified value must be a positive
   integer.
 
-  If you specify a non-zero value for ``--sampleRefreshIntervalSecs``
-  and a schema database with the :option:`--sampleSource
-  <mongosqld --sampleSource>` option,
-  you must also set the :option:`--sampleMode <mongosqld --sampleMode>`
-  option to ``write``. Otherwise, :binary:`~bin.mongosqld` halts with
+  If you specify a non-zero value for ``--schemaRefreshIntervalSecs``
+  and a schema database with the :option:`--schemaSource
+  <mongosqld --schemaSource>` option,
+  you must also set the :option:`--schemaMode <mongosqld --schemaMode>`
+  option to ``auto``. Otherwise, :binary:`~bin.mongosqld` halts with
   an error.
 
   .. include:: /includes/fact-resample-schema-data.rst

--- a/source/includes/options-mongosqld.yaml
+++ b/source/includes/options-mongosqld.yaml
@@ -107,7 +107,7 @@ args: <db-name>
 description: |
   .. versionchanged:: 2.11
 
-     Renamed ``--sampleSource`` to ``-schemaSource``     
+     Renamed ``--sampleSource`` to ``--schemaSource``     
 
   Required when :option:`--schemaMode <mongosqld --schemaMode>` is set
   to ``auto``. Specifies a database to store schema information.
@@ -194,7 +194,7 @@ description: |
   - Sample data from the MongoDB database to generate the
     relational schema and hold the schema in memory.
 
-  - Read previously sampled schema information from the MongoDB
+  - Read a stored schema from the MongoDB
     database named in the
     :option:`--schemaSource <mongosqld --schemaSource>` option.
 

--- a/source/includes/options-mongosqld.yaml
+++ b/source/includes/options-mongosqld.yaml
@@ -205,11 +205,6 @@ description: |
          database specified by the
          :option:`--schemaSource <mongosqld --schemaSource>` option.
 
-  When ``--schemaMode`` is set to ``auto``, :binary:`~bin.mongosqld`
-  samples the schema and writes the schema data to the MongoDB
-  database specified by the
-  :option:`--schemaSource <mongosqld --schemaSource>` option.
-
   For more information on configuring the sample mode, see the
   :ref:`sampling-mode-chart`.
 

--- a/source/includes/sampleSource-example.rst
+++ b/source/includes/sampleSource-example.rst
@@ -1,7 +1,0 @@
-The following example command uses a database named ``sampleDb`` to
-store schema information and sets :option:`--sampleMode <mongosqld
---sampleMode>` to ``write``.
-
-.. code-block:: shell
-
-   mongosqld --sampleSource sampleDb --sampleMode write

--- a/source/includes/schemaSource-example.rst
+++ b/source/includes/schemaSource-example.rst
@@ -1,0 +1,7 @@
+The following example command uses a database named ``sampleDb`` to
+store schema information and sets :option:`--schemaMode <mongosqld
+--schemaMode>` to ``auto``.
+
+.. code-block:: shell
+
+   mongosqld --schemaSource sampleDb --schemaMode auto

--- a/source/reference/mongosqld.txt
+++ b/source/reference/mongosqld.txt
@@ -1032,11 +1032,10 @@ with each.
      - Behavior
 
    * - Standalone Schema
-     - - :option:`--schemaMode <mongosqld --schemaMode>` ``custom``
+     - - :option:`--schemaMode <mongosqld --schemaMode>` *not used*
        - :option:`--schemaSource <mongosqld --schemaSource>` *not used*
-     - :manual:`Standalone </reference/glossary/#term-standalone>`
-       :program:`mongod` instance. :binary:`~bin.mongosqld`
-       samples data upon startup. If :option:`--schemaRefreshIntervalSecs
+     - :binary:`~bin.mongosqld` samples data upon startup. If
+       :option:`--schemaRefreshIntervalSecs
        <mongosqld --schemaRefreshIntervalSecs>` > 0, resample
        at specified interval.
 
@@ -1044,7 +1043,7 @@ with each.
 
           .. code-block:: sh
 
-             mongosqld --schemaMode custom
+             mongosqld --schemaRefreshIntervalSecs 3600
 
        For more information, see :ref:`bi-cached-sampling`.
 
@@ -1052,11 +1051,8 @@ with each.
      - - :option:`--schemaMode <mongosqld --schemaMode>` ``custom``
        - :option:`--schemaSource <mongosqld --schemaSource>` <dbName>
        - :option:`--schemaRefreshIntervalSecs <mongosqld --schemaRefreshIntervalSecs>` *not used*
-     - In a :manual:`replica set </replication/>` or
-       :manual:`sharded cluster </sharding>`
-       environment, sample data only at startup. Read schema data
-       from specified schema database on the :manual:`primary
-       </core/replica-set-primary/>`.
+     - Read schema data from the database specified by
+       :option:`--schemaSource <mongosqld --schemaSource>`.
 
        .. example::
 
@@ -1069,7 +1065,7 @@ with each.
      - - :option:`--schemaMode <mongosqld --schemaMode>` ``auto``
        - :option:`--schemaSource <mongosqld --schemaSource>` <dbName>
        - :option:`--schemaRefreshIntervalSecs  <mongosqld --schemaRefreshIntervalSecs>` > 0
-     - Read and persist schema data in a user-specified schema
+     - Sample and persist schema data in a user-specified schema
        database.
 
        .. example::

--- a/source/reference/mongosqld.txt
+++ b/source/reference/mongosqld.txt
@@ -47,7 +47,7 @@ databases in the target MongoDB instance except the ``admin`` and
 ``local`` databases.
 
 You can specify a database in which to store schema information with
-the :option:`--sampleSource <mongosqld --sampleSource>`
+the :option:`--schemaSource <mongosqld --schemaSource>`
 option. Otherwise, :binary:`~bin.mongosqld` holds the schema in memory.
 
 Starting ``mongosqld`` with a Schema File
@@ -66,12 +66,12 @@ instance.
 Starting ``mongosqld`` with a Schema Database
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use the :option:`--sampleSource <mongosqld --sampleSource>`
+Use the :option:`--schemaSource <mongosqld --schemaSource>`
 option to specify a database to store schema information.
 
 .. code-block:: shell
 
-   mongosqld --sampleSource sampleDb
+   mongosqld --schemaSource sampleDb
 
 Starting ``mongosqld`` with Specified Namespaces
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -159,13 +159,15 @@ Schema Options
 
 .. include:: /includes/option/option-mongosqld-sampleNamespaces.rst
 
-.. include:: /includes/option/option-mongosqld-sampleMode.rst
+.. include:: /includes/option/option-mongosqld-schemaMode.rst
 
-.. include:: /includes/option/option-mongosqld-sampleSource.rst
+.. include:: /includes/option/option-mongosqld-schemaSource.rst
+
+.. include:: /includes/option/option-mongosqld-schemaName.rst
 
 .. include:: /includes/option/option-mongosqld-sampleSize.rst
 
-.. include:: /includes/option/option-mongosqld-sampleRefreshIntervalSecs.rst
+.. include:: /includes/option/option-mongosqld-schemaRefreshIntervalSecs.rst
 
 .. include:: /includes/option/option-mongosqld-uuidSubtype3Encoding.rst
 
@@ -350,13 +352,15 @@ Data Sampling Options
 
    schema:
      sample:
-       mode: <[read|write]>
-       source: <string>
        size: <integer>
        prejoin: <boolean>
        namespaces: <array of strings>
-       refreshIntervalSecs: <integer>
        uuidSubtype3Encoding: <[old|csharp|java]>
+     stored:
+       mode: <[custom|auto]>
+       source: <string>
+       name: <db-name>
+     refreshIntervalSecs: <integer>
 
 .. list-table::
    :header-rows: 1
@@ -365,13 +369,17 @@ Data Sampling Options
      - Type
      - Corresponds to
 
-   * - .. setting:: schema.sample.mode
+   * - .. setting:: schema.stored.mode
      - string
-     - :option:`--sampleMode <mongosqld --sampleMode>`
+     - :option:`--schemaMode <mongosqld --schemaMode>`
 
-   * - .. setting:: schema.sample.source
+   * - .. setting:: schema.stored.source
      - string
-     - :option:`--sampleSource  <mongosqld --sampleSource>`
+     - :option:`--schemaSource  <mongosqld --schemaSource>`
+
+   * - .. setting:: schema.stored.name
+     - string
+     - :option:`--schemaName  <mongosqld --schemaName>`
 
    * - .. setting:: schema.sample.size
      - integer
@@ -385,9 +393,9 @@ Data Sampling Options
      - string or array of strings
      - :option:`--sampleNamespaces <mongosqld --sampleNamespaces>`
 
-   * - .. setting:: schema.sample.refreshIntervalSecs
+   * - .. setting:: schema.refreshIntervalSecs
      - integer
-     - :option:`--sampleRefreshIntervalSecs <mongosqld --sampleRefreshIntervalSecs>`
+     - :option:`--schemaRefreshIntervalSecs <mongosqld --schemaRefreshIntervalSecs>`
 
    * - .. setting:: schema.sample.uuidSubtype3Encoding
      - string
@@ -841,40 +849,40 @@ namespace.
 Specify a Database to Persist a Schema
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use the :option:`--sampleSource <mongosqld --sampleSource>` option to
+Use the :option:`--schemaSource <mongosqld --schemaSource>` option to
 specify a database in which to store schema information. Use the
-:option:`--sampleMode <mongosqld --sampleMode>` option to specify
+:option:`--schemaMode <mongosqld --schemaMode>` option to specify
 whether :binary:`~bin.mongosqld` can write to the schema database or
 only read from it.
 
-.. include:: /includes/sampleSource-example.rst
+.. include:: /includes/schemaSource-example.rst
 
 .. include:: /includes/fact-samplemode-write-permission.rst
 
 Specify a Data Resampling Interval
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use the :option:`--sampleRefreshIntervalSecs <mongosqld
---sampleRefreshIntervalSecs>` option to specify
+Use the :option:`--schemaRefreshIntervalSecs <mongosqld
+--schemaRefreshIntervalSecs>` option to specify
 an interval in seconds for :binary:`~bin.mongosqld` to resample data
 and regenerate the schema. The default value for this option is ``0``,
 which means that :binary:`~bin.mongosqld` never resamples data.
 
 If you set a resampling interval with
-:option:`--sampleRefreshIntervalSecs <mongosqld
---sampleRefreshIntervalSecs>` and you specify a schema
-database with :option:`--sampleSource  <mongosqld --sampleSource>`, you
-cannot set :option:`--sampleMode  <mongosqld --sampleMode>` to ``read``.
+:option:`--schemaRefreshIntervalSecs <mongosqld
+--schemaRefreshIntervalSecs>` and you specify a schema
+database with :option:`--schemaSource  <mongosqld --schemaSource>`, you
+cannot set :option:`--schemaMode  <mongosqld --schemaMode>` to ``custom``.
 
 The following example does not specify a schema database or a schema
 file, so it holds its schema in memory. It uses
-:option:`--sampleRefreshIntervalSecs <mongosqld
---sampleRefreshIntervalSecs>` to specify a data resampling
+:option:`--schemaRefreshIntervalSecs <mongosqld
+--schemaRefreshIntervalSecs>` to specify a data resampling
 interval of 3600 seconds.
 
 .. code-block:: shell
 
-   mongosqld --sampleRefreshIntervalSecs 3600
+   mongosqld --schemaRefreshIntervalSecs 3600
 
 .. _mongosqld-auth-example:
 
@@ -1023,25 +1031,27 @@ with each.
      - ``mongosqld`` Options
      - Behavior
 
-   * - Standalone Reader
-     - - :option:`--sampleMode <mongosqld --sampleMode>` ``read``
-       - :option:`--sampleSource <mongosqld --sampleSource>` *not used*
+   * - Standalone Schema
+     - - :option:`--schemaMode <mongosqld --schemaMode>` ``custom``
+       - :option:`--schemaSource <mongosqld --schemaSource>` *not used*
      - :manual:`Standalone </reference/glossary/#term-standalone>`
        :program:`mongod` instance. :binary:`~bin.mongosqld`
-       samples data upon startup. If :option:`--sampleRefreshIntervalSecs
-       <mongosqld --sampleRefreshIntervalSecs>` > 0, resample
+       samples data upon startup. If :option:`--schemaRefreshIntervalSecs
+       <mongosqld --schemaRefreshIntervalSecs>` > 0, resample
        at specified interval.
 
        .. example::
 
           .. code-block:: sh
 
-             mongosqld --sampleMode read
+             mongosqld --schemaMode custom
 
-   * - Clustered Reader
-     - - :option:`--sampleMode <mongosqld --sampleMode>` ``read``
-       - :option:`--sampleSource <mongosqld --sampleSource>` <dbName>
-       - :option:`--sampleRefreshIntervalSecs <mongosqld --sampleRefreshIntervalSecs>` *not used*
+       For more information, see :ref:`bi-cached-sampling`.
+
+   * - Custom Schema
+     - - :option:`--schemaMode <mongosqld --schemaMode>` ``custom``
+       - :option:`--schemaSource <mongosqld --schemaSource>` <dbName>
+       - :option:`--schemaRefreshIntervalSecs <mongosqld --schemaRefreshIntervalSecs>` *not used*
      - In a :manual:`replica set </replication/>` or
        :manual:`sharded cluster </sharding>`
        environment, sample data only at startup. Read schema data
@@ -1052,13 +1062,13 @@ with each.
 
           .. code-block:: sh
 
-             mongosqld --sampleMode read \
-                       --sampleSource schemaDb
+             mongosqld --schemaMode custom \
+                       --schemaSource schemaDb
 
-   * - Clustered Writer
-     - - :option:`--sampleMode <mongosqld --sampleMode>` ``write``
-       - :option:`--sampleSource <mongosqld --sampleSource>` <dbName>
-       - :option:`--sampleRefreshIntervalSecs  <mongosqld --sampleRefreshIntervalSecs>` > 0
+   * - Auto Schema
+     - - :option:`--schemaMode <mongosqld --schemaMode>` ``auto``
+       - :option:`--schemaSource <mongosqld --schemaSource>` <dbName>
+       - :option:`--schemaRefreshIntervalSecs  <mongosqld --schemaRefreshIntervalSecs>` > 0
      - Read and persist schema data in a user-specified schema
        database.
 
@@ -1066,9 +1076,11 @@ with each.
 
           .. code-block:: sh
 
-              mongosqld --sampleMode write \
-                        --sampleSource schemaDb \
-                        --sampleRefreshIntervalSecs 3600
+              mongosqld --schemaMode auto \
+                        --schemaSource schemaDb \
+                        --schemaRefreshIntervalSecs 3600
+
+       For more information, see :ref:`bi-persistent-schema`.
 
 Invalid Configurations
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -1085,22 +1097,22 @@ and cause an error at startup.
      - Behavior
 
    * - Standalone Writer (**invalid**)
-     - - :option:`--sampleMode <mongosqld --sampleMode>` ``write``
-       - :option:`--sampleSource <mongosqld --sampleMode>` *not used*
+     - - :option:`--schemaMode <mongosqld --schemaMode>` ``auto``
+       - :option:`--schemaSource <mongosqld --schemaSource>` *not used*
      - This configuration is invalid for a :manual:`standalone
        </reference/glossary/#term-standalone>`
-       :binary:`~bin.mongod` instance because in ``write`` mode there
+       :binary:`~bin.mongod` instance because in ``auto`` mode there
        must be a writeable database specified.
 
    * - Clustered Sampling Reader (**invalid**)
-     - - :option:`--sampleMode <mongosqld --sampleMode>` ``read``
-       - :option:`--sampleSource <mongosqld --sampleSource>` <dbName>
-       - :option:`--sampleRefreshIntervalSecs <mongosqld --sampleRefreshIntervalSecs>` > 0
+     - - :option:`--schemaMode <mongosqld --schemaMode>` ``custom``
+       - :option:`--schemaSource <mongosqld --schemaSource>` <dbName>
+       - :option:`--schemaRefreshIntervalSecs <mongosqld --schemaRefreshIntervalSecs>` > 0
      - When used in a MongoDB :manual:`replica set
        </replication/>` or :manual:`sharded cluster </sharding>`,
        this configuration is invalid. When a
        database is specified for storing schema data with
-       :option:`--sampleSource <mongosqld --sampleSource>`, :option:`--sampleMode <mongosqld --sampleMode>` must be set to
-       ``write`` so that the schema may be updated from
+       :option:`--schemaSource <mongosqld --schemaSource>`, :option:`--schemaMode <mongosqld --schemaMode>` must be set to
+       ``auto`` so that the schema may be updated from
        the :manual:`primary </core/replica-set-primary/>` to
        maintain cluster-wide consistency.

--- a/source/reference/user-authorization.txt
+++ b/source/reference/user-authorization.txt
@@ -55,7 +55,7 @@ required MongoDB :manual:`privilege action </reference/privilege-actions>`:
 
        - :authaction:`insert` and :authaction:`update` on the schema
          database specified by
-         :option:`--sampleSource <mongosqld --sampleSource>`
+         :option:`--schemaSource <mongosqld --schemaSource>`
 
    * - :xml:`<mono><link target="https://dev.mysql.com/doc/refman/5.7/en/kill.html">KILL</link></mono>`
      - - :xml:`<mono><link target="https://dev.mysql.com/doc/refman/5.7/en/privileges-provided.html#priv_process">PROCESS</link></mono>`
@@ -101,7 +101,7 @@ required MongoDB :manual:`privilege action </reference/privilege-actions>`:
 
        :authaction:`insert` and :authaction:`update` on the schema
        database specified by
-       :option:`--sampleSource <mongosqld --sampleSource>`.
+       :option:`--schemaSource <mongosqld --schemaSource>`.
 
    * - :xml:`<mono><link target="https://dev.mysql.com/doc/refman/5.7/en/set-variable.html">SET (Variables)</link></mono>`
      - :xml:`<mono><link target="https://dev.mysql.com/doc/refman/5.7/en/privileges-provided.html#priv_super">SUPER</link></mono>`

--- a/source/schema-configuration.txt
+++ b/source/schema-configuration.txt
@@ -17,7 +17,7 @@ creating and managing a relational schema.
 For complete documentation on |bi-short|'s schema management options,
 see the :binary:`~bin.mongosqld` reference documentation.
 
-:ref:`Cached Sampling <bi-cached-sampling>`
+:ref:`bi-cached-sampling`
 -------------------------------------------
 
 .. container:: admonition
@@ -27,15 +27,15 @@ see the :binary:`~bin.mongosqld` reference documentation.
    :binary:`~bin.mongosqld` derives the schema on startup and holds the
    schema in memory.
    
-:ref:`Persist a Schema in MongoDB <bi-persistent-schema>`
+:ref:`bi-persistent-schema`
 ---------------------------------------------------------
 
 .. container:: admonition
 
    :binary:`~bin.mongosqld` samples your MongoDB collections and
    creates a schema at the time of startup and writes it to a
-   MongoDB collection. Available via the :option:`--sampleSource
-   <mongosqld --sampleSource>` option.
+   MongoDB collection. Available via the :option:`--schemaSource
+   <mongosqld --schemaSource>` option.
 
 :ref:`Use MongoDB Views <schema-with-views>`
 --------------------------------------------

--- a/source/schema/cached-sampling.txt
+++ b/source/schema/cached-sampling.txt
@@ -1,8 +1,8 @@
 .. _bi-cached-sampling:
 
-===============
-Cached Sampling
-===============
+========================================
+Standalone Schema Mode (Cached Sampling)
+========================================
 
 .. default-domain:: mongodb
 

--- a/source/schema/persist-schema.txt
+++ b/source/schema/persist-schema.txt
@@ -1,8 +1,8 @@
 .. _bi-persistent-schema:
 
-========================================
-Persist a {+bi-short+} Schema in MongoDB
-========================================
+==============================================
+Auto Schema Mode (Persist a Schema in MongoDB)
+==============================================
 
 .. default-domain:: mongodb
 
@@ -15,34 +15,37 @@ Persist a {+bi-short+} Schema in MongoDB
 Overview
 --------
 
-The :option:`--sampleSource <mongosqld --sampleSource>`
+The :option:`--schemaSource <mongosqld --schemaSource>`
 option directs :binary:`~bin.mongosqld` to
 use a particular database on the connected MongoDB instance for schema
 storage. :binary:`~bin.mongosqld` can either create a new database to
 use for schema storage or use an existing database.
 
 If you specify an existing database which has been used previously
-for schema storage, the :option:`--sampleMode 
-<mongosqld --sampleMode>` option determines
+for schema storage, the :option:`--schemaMode 
+<mongosqld --schemaMode>` option determines
 whether :binary:`~bin.mongosqld` writes new schema data to the specified
 database or only reads from it. If you specify a database which
-doesn't currently exist, you must set :option:`--sampleMode
-<mongosqld --sampleMode>` to
-``write``.
+doesn't currently exist, you must set :option:`--schemaMode
+<mongosqld --schemaMode>` to
+``auto``.
 
-.. include:: /includes/sampleSource-example.rst
+.. include:: /includes/schemaSource-example.rst
+
+.. include:: /includes/sampling-ref-chart-link.rst
+
+Regenerate the Schema
+---------------------
 
 .. include:: /includes/fact-sampleRefresh.rst
 
 .. include:: /includes/fact-resample-schema-data.rst
 
-.. include:: /includes/sampling-ref-chart-link.rst
-
 User Permissions for Persisted Schemas
 --------------------------------------
 
 If your MongoDB instance uses authentication, you must specify a
-MongoDB user with ``write`` permission on the specified schema database
+MongoDB user with write permission on the specified schema database
 in addition to the permissions described under
 :ref:`cached sampling <bi-cached-sampling>`.
 
@@ -52,7 +55,7 @@ a custom role with the minimum required permissions as described in
 :ref:`User Permissions for Cached Sampling
 <cached-sampling-user-permissions>`, or use the built-in
 :manual:`readAnyDatabase </core/security-built-in-roles/>` role. In
-either case, the user also needs ``write`` permission on the
+either case, the user also needs write permission on the
 specified schema database.
 
 .. code-block:: javascript
@@ -74,4 +77,4 @@ database called ``schemaDb``.
 
 .. code-block:: shell
 
-   mongosqld --auth -u bicUser -p myPass --sampleSource schemaDb --sampleMode write
+   mongosqld --auth -u bicUser -p myPass --schemaSource schemaDb --schemaMode auto

--- a/source/schema/resample-schema.txt
+++ b/source/schema/resample-schema.txt
@@ -37,6 +37,6 @@ the ``FLUSH SAMPLE`` command from within the
 
    :option:`--sampleNamespaces <mongosqld --sampleNamespaces>`
 
-   :option:`--sampleSource <mongosqld --sampleSource>`
+   :option:`--schemaSource <mongosqld --schemaSource>`
 
-   :option:`--sampleMode <mongosqld --sampleMode>`
+   :option:`--schemaMode <mongosqld --schemaMode>`

--- a/source/schema/type-conflicts.txt
+++ b/source/schema/type-conflicts.txt
@@ -38,7 +38,7 @@ documents and arrays.
 
    For more information on sampling configuration, such as setting
    the :option:`--samplesize <mongosqld --sampleSize>` and
-   :option:`sampleRefreshIntervalSecs <mongosqld --sampleRefreshIntervalSecs>`,
+   :option:`--schemaRefreshIntervalSecs <mongosqld --schemaRefreshIntervalSecs>`,
    see :ref:`msqld-schema-options`.
 
 Scalar-Scalar Conflicts


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/DOCSP-5779

**Staging**

- `--schemaMode` : https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/jdestefano/DOCSP-5779/reference/mongosqld.html#cmdoption-mongosqld-schemamode

- `--schemaSource` : https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/jdestefano/DOCSP-5779/reference/mongosqld.html#cmdoption-mongosqld-schemasource

- `--schemaName` : https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/jdestefano/DOCSP-5779/reference/mongosqld.html#cmdoption-mongosqld-schemaname

- Config file settings: https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/jdestefano/DOCSP-5779/reference/mongosqld.html#data-sampling-options

- Schema Sampling Reference Chart: https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/jdestefano/DOCSP-5779/reference/mongosqld.html#sampling-mode-reference-chart

- Schema Mapping Landing Page: https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/jdestefano/DOCSP-5779/schema-configuration.html

- Pages renamed and examples updated:
  - https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/jdestefano/DOCSP-5779/schema/cached-sampling.html
  - https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/jdestefano/DOCSP-5779/schema/persist-schema.html