### PR TITLE
Modify snooty.toml slug

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -1,1 +1,1 @@
-name = "docs-bi-connector"
+name = "bi-connector"


### PR DESCRIPTION
Most repos I've seen don't include `docs-` in the slug defined in their snooty.toml. If this change wouldn't break anything, I propose standardizing our naming scheme.