### PR TITLE
[BIC] Only use GSSAPI proxy creds for constrained delegation

### DIFF
--- a/source/includes/options-mongosqld.yaml
+++ b/source/includes/options-mongosqld.yaml
@@ -789,6 +789,20 @@ optional: true
 default: First IP address for :setting:`net.bindIp`.
 ---
 program: mongosqld
+name: gssapiConstrainedDelegation
+directive: option
+description: |
+  .. versionadded:: 2.11
+
+  Use proxy credentials for Kerberos authorization, enabling constrained
+  delegation. Requires :binary:`~bin.mongosqld` service credentials to be
+  present in the client keytab. See :ref:`configure-kerberos` for more
+  information about Kerberos configuration.
+
+optional: true
+default: false
+---
+program: mongosqld
 name: gssapiServiceName
 directive: option
 args: <service-name>

--- a/source/includes/options-mongosqld.yaml
+++ b/source/includes/options-mongosqld.yaml
@@ -796,8 +796,8 @@ description: |
 
   Use proxy credentials for Kerberos authorization, enabling constrained
   delegation. Requires :binary:`~bin.mongosqld` service credentials to be
-  present in the client keytab. See :ref:`configure-kerberos` for more
-  information about Kerberos configuration.
+  present in the client keytab as well as the service keytab. See
+  :ref:`configure-kerberos` for more information about Kerberos configuration.
 
 optional: true
 default: false

--- a/source/reference/mongosqld.txt
+++ b/source/reference/mongosqld.txt
@@ -258,6 +258,8 @@ Kerberos Options
 
 .. include:: /includes/option/option-mongosqld-mongo-gssapiServiceName.rst
 
+.. include:: /includes/option/option-mongosqld-gssapiConstrainedDelegation.rst
+
 .. _msqld-socket-options:
 
 Socket Options
@@ -554,6 +556,10 @@ Security Options
    * - .. setting:: security.gssapi.serviceName
      - string
      - :option:`--gssapiServiceName`
+
+   * - .. setting:: security.gssapi.constrainedDelegation
+     - string
+     - :option:`--gssapiConstrainedDelegation`
 
 .. _msqld-conf-host-options:
 

--- a/source/tutorial/kerberos.txt
+++ b/source/tutorial/kerberos.txt
@@ -1,5 +1,7 @@
 :noprevnext:
 
+.. _configure-kerberos:
+
 =================================
 Configure Kerberos for |bi-short|
 =================================


### PR DESCRIPTION
Staged: [mongosqld](https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/stevenrenaker/DOCSP-5844/reference/mongosqld.html#cmdoption-mongosqld-gssapiconstraineddelegation)