### PR TITLE
(DOCSP-7244) Add incompatibility warning for ODBC Manager with macOS Catalina

### DIFF
--- a/source/includes/steps-create-system-dsn-macos.yaml
+++ b/source/includes/steps-create-system-dsn-macos.yaml
@@ -6,6 +6,8 @@ content: |
   .. note::
 
      ODBC Manager is included with the |odbc-driver-name|.
+
+  .. include:: /includes/temp-warn-odbc-catalina.txt
 ---
 title: Click :guilabel:`System DSN`, then click :guilabel:`Add`.
 ref: click-system-dsn-macos

--- a/source/includes/temp-warn-odbc-catalina.txt
+++ b/source/includes/temp-warn-odbc-catalina.txt
@@ -1,8 +1,8 @@
 .. (DOCSP-7244) This is a temporary warning that will be removed with BI-2371
 
-.. warning::
+.. important::
 
    The 1.0.16 edition of ODBC Manager included with the MongoDB ODBC
    driver is not compatible with macOS Catalina. If you are on
-   Catalina, download the 
+   Catalina, download and install the 
    `latest version (1.0.19) of ODBC manager. <http://www.odbcmanager.net/index.php>`__

--- a/source/includes/temp-warn-odbc-catalina.txt
+++ b/source/includes/temp-warn-odbc-catalina.txt
@@ -2,5 +2,7 @@
 
 .. warning::
 
-   The current edition of ODBC Manager is not compatible with macOS
-   Catalina.
+   The 1.0.16 edition of ODBC Manager included with the MongoDB ODBC
+   driver is not compatible with macOS Catalina. If you are on
+   Catalina, download the 
+   `latest version (1.0.19) of ODBC manager. <http://www.odbcmanager.net/index.php>`__

--- a/source/includes/temp-warn-odbc-catalina.txt
+++ b/source/includes/temp-warn-odbc-catalina.txt
@@ -1,0 +1,6 @@
+.. (DOCSP-7244) This is a temporary warning that will be removed with BI-2371
+
+.. warning::
+
+   The current edition of ODBC Manager is not compatible with macOS
+   Catalina.

--- a/source/reference/odbc-driver.txt
+++ b/source/reference/odbc-driver.txt
@@ -41,6 +41,9 @@ The {+odbc-driver+} is available for:
 
 - Windows (32-bit and 64-bit)
 - macOS
+
+.. include:: /includes/temp-warn-odbc-catalina.txt
+
 - Ubuntu 14.04 and 16.04
 - RHEL 7
 

--- a/source/reference/odbc-driver.txt
+++ b/source/reference/odbc-driver.txt
@@ -42,7 +42,7 @@ The {+odbc-driver+} is available for:
 - Windows (32-bit and 64-bit)
 - macOS
 
-.. include:: /includes/temp-warn-odbc-catalina.txt
+  .. include:: /includes/temp-warn-odbc-catalina.txt
 
 - Ubuntu 14.04 and 16.04
 - RHEL 7


### PR DESCRIPTION
[Ticket](https://jira.mongodb.org/browse/DOCSP-7244)

Added warning file 'temp-warn-odbc-catalina'

Warning file included on:

- Components/[MongoDB ODBC Driver page](https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/zach.carr/DOCSP-7244/reference/odbc-driver.html)

- [Create a System DSN](https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/zach.carr/DOCSP-7244/tutorial/create-system-dsn.html), under macOS tab