### PR TITLE
DOP-1345: build BI Connector on snooty

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -1,4 +1,12 @@
 name = "bi-connector"
+title = "MongoDB Connector for BI"
+
+intersphinx = ["https://docs.mongodb.com/manual/objects.inv", 
+               "https://docs.atlas.mongodb.com/objects.inv"]
+
+toc_landing_pages = ["/installation", "/client-applications", "/connect/mysql", "/connect/tableau", 
+                     "/authentication", "/schema-configuration", "/components", "/reference", 
+                     "/release-notes"]
 
 [constants]
 bi-atlas-short = "BI Connector for Atlas"
@@ -10,9 +18,6 @@ download-center-url = "https://www.mongodb.com/download-center/bi-connector"
 odbc-driver = "`MongoDB ODBC Driver for BI Connector <https://github.com/mongodb/mongo-odbc-driver/releases/>`__"
 
 [substitutions]
-branch = "``{0}``'.format(conf.git.branches.current)"
-copy = "unicode:: U+000A9',"
-year = "{0}'.format(datetime.date.today().year)"
 ent-build = "MongoDB Enterprise"
 hardlink = "https://docs.mongodb.com/bi-connector/"
 adc = ":abbr:`ADC (Active Directory Controller)`"

--- a/snooty.toml
+++ b/snooty.toml
@@ -9,13 +9,18 @@ toc_landing_pages = ["/installation", "/client-applications", "/connect/mysql",
                      "/release-notes"]
 
 [constants]
+atlas = "MongoDB Atlas"
 bi-atlas-short = "BI Connector for Atlas"
+bi-full = "MongoDB Connector for Business Intelligence"
 bi-short = "BI Connector"
+cm-full = "MongoDB Cloud Manager"
 download-center = "`MongoDB Download Center <https://www.mongodb.com/download-center/bi-connector>`__"
 download-center-bi = "`MongoDB Connector for BI <https://www.mongodb.com/download-center/bi-connector>`__"
 download-center-tableau = "`MongoDB Connector for BI <https://www.mongodb.com/download-center/bi-connector?jmp=tbl>`__"
 download-center-url = "https://www.mongodb.com/download-center/bi-connector"
+java-plugin = "MongoSQL Authentication Plugin for MySQL Connector/J"
 odbc-driver = "`MongoDB ODBC Driver for BI Connector <https://github.com/mongodb/mongo-odbc-driver/releases/>`__"
+om-full = "MongoDB Ops Manager"
 
 [substitutions]
 ent-build = "MongoDB Enterprise"
@@ -27,8 +32,10 @@ bi-atlas = "MongoDB Connector for Business Intelligence for MongoDB Atlas"
 bi-short = "BI Connector"
 bi = "MongoDB Connector for BI"
 cidr = ":abbr:`CIDR (Classless Inter-Domain Routing)`"
+csr = ":abbr:`CSR (Certificate Signing Request)`"
 dsn = ":abbr:`DSN (Data Source Name)`"
 epoch-time = "Timestamp in the number of seconds that have elapsed since the `UNIX epoch <https://en.wikipedia.org/wiki/Unix_time?oldid=828172017>`__"
+fqdn = ":abbr:`FQDN (Fully Qualified Domain Name)`"
 https = ":abbr:`HTTPS (Secure HyperText Transport Protocol)`"
 http = ":abbr:`HTTP (HyperText Transport Protocol)`"
 iana = ":abbr:`IANA (Internet Assigned Numbers Authority)`"

--- a/snooty.toml
+++ b/snooty.toml
@@ -4,8 +4,8 @@ title = "MongoDB Connector for BI"
 intersphinx = ["https://docs.mongodb.com/manual/objects.inv", 
                "https://docs.atlas.mongodb.com/objects.inv"]
 
-toc_landing_pages = ["/installation", "/client-applications", "/connect/mysql", "/connect/tableau", 
-                     "/authentication", "/schema-configuration", "/components", "/reference", 
+toc_landing_pages = ["/installation", "/client-applications", "/connect/mysql", 
+                     "/authentication", "/schema-configuration", "/components", 
                      "/release-notes"]
 
 [constants]

--- a/source/atlas-bi-connector.txt
+++ b/source/atlas-bi-connector.txt
@@ -24,5 +24,5 @@ To install the {+bi-full+} on premises, see the
 .. note::
 
    You can also deploy the {+bi-full+} to the
-   :cm:`{+cm-full+} </tutorial/deploy-bi-connector/>` or
-   :om:`{+om-full+} </tutorial/deploy-bi-connector/>`.
+   :cloudmgr:`{+cm-full+} </tutorial/deploy-bi-connector/>` or
+   :opsmgr:`{+om-full+} </tutorial/deploy-bi-connector/>`.

--- a/source/authentication.txt
+++ b/source/authentication.txt
@@ -308,11 +308,10 @@ and password), |ldap|, or Kerberos:
 
 .. include:: /includes/auth-mechanisms-example.rst
 
-.. class:: hidden
 
-   .. toctree::
-      :titlesonly:
+.. toctree::
+   :titlesonly:
 
-      /reference/auth-plugin-c
-      /reference/auth-plugin-jdbc
-      /tutorial/kerberos
+   /reference/auth-plugin-c
+   /reference/auth-plugin-jdbc
+   /tutorial/kerberos

--- a/source/authentication.txt
+++ b/source/authentication.txt
@@ -269,7 +269,14 @@ authenticate using your BI tool, install either the C or JDBC
 authentication plugin depending on which is compatible with your BI
 Tool:
 
-.. include:: /includes/toc/dfn-list-client-dependencies.rst
+:doc:`/reference/auth-plugin-c`
+   Instructions for installing the C Authentication Plugin, which 
+   facilitates authentication between the BI Connector and SQL clients 
+   such as :doc:`Tableau </connect/tableau>` and the 
+   :doc:`MySQL shell </connect/mysql>`.
+
+:doc:`/reference/auth-plugin-jdbc`
+   Instructions for installing the JDBC Authentication Plugin.
 
 For more
 information on connecting BI Tools to the |bi-short|, see

--- a/source/client-applications.txt
+++ b/source/client-applications.txt
@@ -75,16 +75,15 @@ Intelligence tools.
      link: https://docs.mongodb.com/bi-connector/current/connect/looker
 
 
-.. class:: hidden
 
-   .. toctree::
-      :titlesonly:
+.. toctree::
+   :titlesonly:
 
-      /connect/excel
-      /connect/mysql
-      /connect/tableau
-      /connect/qlik
-      /connect/microstrategy
-      /connect/powerbi
-      /connect/spotfire-cloud
-      /connect/looker
+   /connect/excel
+   /connect/mysql
+   /connect/tableau
+   /connect/qlik
+   /connect/microstrategy
+   /connect/powerbi
+   /connect/spotfire-cloud
+   /connect/looker

--- a/source/components.txt
+++ b/source/components.txt
@@ -37,12 +37,11 @@ The following tools are available for use with the |bi|:
   facilitate secure transmission of authentication credentials between
   :binary:`~bin.mongosqld` and a MySQL client.
 
-.. class:: hidden
 
-   .. toctree::
-      :titlesonly:
+.. toctree::
+   :titlesonly:
 
-      /reference/mongosqld
-      /reference/mongodrdl
-      /reference/mongotranslate
-      MongoDB ODBC Driver </reference/odbc-driver>
+   /reference/mongosqld
+   /reference/mongodrdl
+   /reference/mongotranslate
+   MongoDB ODBC Driver </reference/odbc-driver>

--- a/source/connect/tableau-no-auth.txt
+++ b/source/connect/tableau-no-auth.txt
@@ -1,5 +1,7 @@
 :noprevnext:
 
+.. _connect-with-tableau:
+
 ==============================================================
 Connect from Tableau Desktop without Authentication or TLS/SSL
 ==============================================================

--- a/source/connect/tableau.txt
+++ b/source/connect/tableau.txt
@@ -6,18 +6,6 @@ Connect from Tableau Desktop
 
 .. default-domain:: mongodb
 
-.. contents:: On this page
-   :local:
-   :backlinks: none
-   :depth: 1
-   :class: singlecol
-
-.. _connect-with-tableau:
-
-.. versionadded:: 2.2
-
-.. include:: /includes/toc/dfn-list-tableau.rst
-
 .. toctree::
    :titlesonly:
 

--- a/source/connect/tableau.txt
+++ b/source/connect/tableau.txt
@@ -17,11 +17,10 @@ Connect from Tableau Desktop
 .. versionadded:: 2.2
 
 .. include:: /includes/toc/dfn-list-tableau.rst
-.. class:: hidden
 
-   .. toctree::
-      :titlesonly:
+.. toctree::
+   :titlesonly:
 
-      /connect/tableau-no-auth
-      /connect/tableau-auth
-      /connect/tableau-auth-ssl
+   /connect/tableau-no-auth
+   /connect/tableau-auth
+   /connect/tableau-auth-ssl

--- a/source/includes/c-auth-supported-platforms.rst
+++ b/source/includes/c-auth-supported-platforms.rst
@@ -8,7 +8,6 @@ The plugin is built and tested on the following platforms:
 
 - RHEL 7.0 (64-bit)
 
-.. admonition:: Testing Environment
-   :class: important
+.. important:: Testing Environment
 
    .. include:: /includes/fact-c-auth-compatibility.rst

--- a/source/includes/fact-mongodrdl-example.rst
+++ b/source/includes/fact-mongodrdl-example.rst
@@ -11,7 +11,7 @@ database ``test``:
 
 Run :binary:`~bin.mongodrdl` to generate a schema based on this collection:
 
-.. class:: copyable-code
+
 .. code-block:: sh
 
    mongodrdl -d test -c abc -o schema.drdl

--- a/source/includes/fact-v210-schema-options.rst
+++ b/source/includes/fact-v210-schema-options.rst
@@ -1,2 +1,2 @@
 To learn more about version 2.10's schema options, see the
-:v2.10:`2.10 documentation </reference/mongosqld/#schema-options>`.
+:bic-v2.10:`2.10 documentation </reference/mongosqld/#schema-options>`.

--- a/source/includes/steps-local-quickstart.yaml
+++ b/source/includes/steps-local-quickstart.yaml
@@ -82,7 +82,7 @@ level: 4
 stepnum: 3
 content: |
   Create a System DSN by following instructions in the :ref:`tutorial
-  <create-system-dsn>`. For the
+  <create-system-dsn-bi-connector>`. For the
   purposes of this local test installation you can leave the
   :guilabel:`User`, :guilabel:`Password` and :guilabel:`Authentication`
   fields blank, because :binary:`~bin.mongosqld` is running without the

--- a/source/index.txt
+++ b/source/index.txt
@@ -119,20 +119,19 @@ data visualization with |bi-short|.
 Learn more about setting up a local |bi-short| test installation
 in the :doc:`Quick Start Guide </local-quickstart>`.
 
-.. class:: hidden
 
-   .. toctree::
-      :titlesonly:
+.. toctree::
+   :titlesonly:
 
-      Quick Start Guide </local-quickstart>
-      /atlas-bi-connector
-      Install BI Connector</installation>
-      /launch
-      /tutorial/create-system-dsn
-      Connect BI Tools </client-applications>
-      /authentication
-      /schema-configuration
-      Components </components>
-      /reference
-      FAQ </faq>
-      Release Notes </release-notes>
+   Quick Start Guide </local-quickstart>
+   /atlas-bi-connector
+   Install BI Connector</installation>
+   /launch
+   /tutorial/create-system-dsn
+   Connect BI Tools </client-applications>
+   /authentication
+   /schema-configuration
+   Components </components>
+   /reference
+   FAQ </faq>
+   Release Notes </release-notes>

--- a/source/index.txt
+++ b/source/index.txt
@@ -32,6 +32,7 @@ business intelligence tools.
 .. figure:: /images/bi-connector/cloud-none-vert.png
    :figwidth: 536px
    :align: center
+   :alt: Diagram showing that other BI tools communicate with the DSN, which communicates with MongoDB's BI Connector, which in turn communicates with the MongoDB database.
 
 System Components
 -----------------

--- a/source/installation.txt
+++ b/source/installation.txt
@@ -23,7 +23,14 @@ the guide for your platform below to install the |bi-short|, or see
 Installation Guides
 -------------------
 
-.. include:: /includes/toc/dfn-list-install.rst
+:doc:`/tutorial/install-bi-connector-windows`
+    Instructions for installing the BI Connector on Windows systems.
+:doc:`/tutorial/install-bi-connector-macos`
+    Instructions for installing the BI Connector on macOS systems.
+:doc:`/tutorial/install-bi-connector-rhel`
+    Instructions for installing the BI Connector on RHEL-based systems.
+:doc:`/tutorial/install-bi-connector-debian`
+    Instructions for installing the BI Connector on debian-based systems. 
 
 Supported Platforms
 -------------------

--- a/source/installation.txt
+++ b/source/installation.txt
@@ -87,12 +87,11 @@ systems:
 
 - PPC64LE systems running Red Hat Enterprise Linux 7.1+
 
-.. class:: hidden
 
-   .. toctree::
-      :titlesonly:
+.. toctree::
+   :titlesonly:
 
-      /tutorial/install-bi-connector-windows
-      /tutorial/install-bi-connector-macos
-      /tutorial/install-bi-connector-rhel
-      /tutorial/install-bi-connector-debian
+   /tutorial/install-bi-connector-windows
+   /tutorial/install-bi-connector-macos
+   /tutorial/install-bi-connector-rhel
+   /tutorial/install-bi-connector-debian

--- a/source/launch.txt
+++ b/source/launch.txt
@@ -223,7 +223,7 @@ Install ``mongosqld`` as a System Service
        content: |
 
 |bi-short| requires a configuration file with the
-:setting:`systemLog.path` setting specified when running as a
+:setting:`~mongosqld.systemLog.path` setting specified when running as a
 system service. Using your preferred text editor, create a
 ``mongosqld.conf`` file. To review the configuration file options,
 see :ref:`Configuration File <config-format>`. For example:

--- a/source/reference.txt
+++ b/source/reference.txt
@@ -12,15 +12,14 @@ Reference
 
 .. include:: /includes/toc/dfn-list-reference-landing.rst
 
-.. class:: hidden
 
-   .. toctree::
-      :titlesonly:
+.. toctree::
+   :titlesonly:
 
-      /tutorial/ssl-setup
-      /reference/drdl
-      /reference/log-messages
-      /reference/type-conversion
-      /reference/user-authorization
-      /reference/system-variables
-      /supported-operations
+   /tutorial/ssl-setup
+   /reference/drdl
+   /reference/log-messages
+   /reference/type-conversion
+   /reference/user-authorization
+   /reference/system-variables
+   /supported-operations

--- a/source/reference.txt
+++ b/source/reference.txt
@@ -4,15 +4,6 @@ Reference
 
 .. default-domain:: mongodb
 
-.. contents:: On this page
-   :local:
-   :backlinks: none
-   :depth: 1
-   :class: singlecol
-
-.. include:: /includes/toc/dfn-list-reference-landing.rst
-
-
 .. toctree::
    :titlesonly:
 

--- a/source/reference/auth-plugin-jdbc.txt
+++ b/source/reference/auth-plugin-jdbc.txt
@@ -2,6 +2,8 @@
 JDBC Authentication Plugin
 ==========================
 
+.. default-domain:: mongodb
+
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -35,7 +37,7 @@ Download from the :github:`GitHub repository </mongodb/mongosql-auth-java/releas
 Use `Maven <https://maven.apache.org/>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Include the `plugin <https://mvnrepository.com/artifact/org.mongodb/mongosql-auth>`__
+1. Include the `{+java-plugin+} <https://mvnrepository.com/artifact/org.mongodb/mongosql-auth>`__
    library in the ``CLASSPATH``. The Maven coordinates are:
 
    .. code-block:: xml
@@ -70,7 +72,7 @@ Use `Maven <https://maven.apache.org/>`__
    .. seealso::
 
       To learn about the ``authenticationPlugins`` query parameter,
-      see the :mysql:`MySQL documentation 
+      see the `MySQL documentation 
       <https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-configuration-properties.html>`__.
 
    You may also specify the authentication mechanism and authentication

--- a/source/reference/auth-plugin-jdbc.txt
+++ b/source/reference/auth-plugin-jdbc.txt
@@ -27,7 +27,7 @@ Installing the Plugin
 To download the plugin ``.jar`` file, choose one of the following
 options:
 
-Download from the :gh:`GitHub repository </mongodb/mongosql-auth-java/releases/>`
+Download from the :github:`GitHub repository </mongodb/mongosql-auth-java/releases/>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. Select the ``.jar`` file from the download site.

--- a/source/reference/auth-plugin-jdbc.txt
+++ b/source/reference/auth-plugin-jdbc.txt
@@ -17,7 +17,9 @@ JDBC Authentication Plugin
 Prerequisites
 -------------
 
-This plugin requires a version of MySQL Connector/J between :mvn:`5.1.39 </mysql/mysql-connector-java/5.1.39>` and the latest 5.1.x. It can't use MySQL Server or MySQL Connector/J 8.0 or later.
+This plugin requires a version of MySQL Connector/J between 
+`5.1.39 <https://mvnrepository.com/artifact/mysql/mysql-connector-java/5.1.39>`__ 
+and the latest 5.1.x. It can't use MySQL Server or MySQL Connector/J 8.0 or later.
 
 Installing the Plugin
 ---------------------
@@ -35,7 +37,7 @@ Download from the :gh:`GitHub repository </mongodb/mongosql-auth-java/releases/>
 Use `Maven <https://maven.apache.org/>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Include the :mvn:`{+java-plugin+} </org.mongodb/mongosql-auth>`
+1. Include the `{+java-plugin+} <https://mvnrepository.com/artifact/org.mongodb/mongosql-auth>`__
    library in the ``CLASSPATH``. The Maven coordinates are:
 
    .. code-block:: xml
@@ -50,7 +52,7 @@ Use `Maven <https://maven.apache.org/>`__
       To learn more about Maven, refer to its `documentation site
       <https://maven.apache.org/guides/index.html>`_.
 
-#. Include :mvn:`MySQL Connector/J </mysql/mysql-connector-java>`
+#. Include `MySQL Connector/J <https://mvnrepository.com/artifact/mysql/mysql-connector-java>`__
    in the ``CLASSPATH``. The Maven coordinates are:
 
    .. code-block:: xml
@@ -70,7 +72,8 @@ Use `Maven <https://maven.apache.org/>`__
    .. seealso::
 
       To learn about the ``authenticationPlugins`` query parameter,
-      see the :mysql:`MySQL documentation </doc/connector-j/5.1/en/connector-j-reference-configuration-properties.html>`.
+      see the :mysql:`MySQL documentation 
+      <https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-configuration-properties.html>`__.
 
    You may also specify the authentication mechanism and authentication
    source as a query parameter on the ``username``.

--- a/source/reference/auth-plugin-jdbc.txt
+++ b/source/reference/auth-plugin-jdbc.txt
@@ -2,8 +2,6 @@
 JDBC Authentication Plugin
 ==========================
 
-.. default-domain:: mongodb
-
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -28,7 +26,7 @@ To download the plugin ``.jar`` file, choose one of the following
 options:
 
 Download from the :github:`GitHub repository </mongodb/mongosql-auth-java/releases/>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. Select the ``.jar`` file from the download site.
 
@@ -37,7 +35,7 @@ Download from the :github:`GitHub repository </mongodb/mongosql-auth-java/releas
 Use `Maven <https://maven.apache.org/>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Include the `{+java-plugin+} <https://mvnrepository.com/artifact/org.mongodb/mongosql-auth>`__
+1. Include the `plugin <https://mvnrepository.com/artifact/org.mongodb/mongosql-auth>`__
    library in the ``CLASSPATH``. The Maven coordinates are:
 
    .. code-block:: xml
@@ -50,7 +48,7 @@ Use `Maven <https://maven.apache.org/>`__
 
    .. seealso::
       To learn more about Maven, refer to its `documentation site
-      <https://maven.apache.org/guides/index.html>`_.
+      <https://maven.apache.org/guides/index.html>`__.
 
 #. Include `MySQL Connector/J <https://mvnrepository.com/artifact/mysql/mysql-connector-java>`__
    in the ``CLASSPATH``. The Maven coordinates are:

--- a/source/reference/mongodrdl.txt
+++ b/source/reference/mongodrdl.txt
@@ -10,18 +10,14 @@
    :depth: 1
    :class: singlecol
 
-.. only:: html
-
-   .. meta::
-      :description: The mongodrdl command man page.
-      :keywords: mongodrdl, mongodb, man page
+.. meta::
+   :description: The mongodrdl command man page.
+   :keywords: mongodrdl, mongodb, man page
 
 Description
 -----------
 
-.. only:: (not man)
-
-   .. binary:: mongodrdl
+.. binary:: mongodrdl
 
 .. include:: /includes/fact-bi-enterprise.rst
 

--- a/source/reference/mongodrdl.txt
+++ b/source/reference/mongodrdl.txt
@@ -274,7 +274,7 @@ To create a :ref:`.drdl <drdl>` file from a
 :manual:`mongod </reference/mongod>` instance with authentication
 enabled, use the following command format:
 
-.. class:: copyable-code
+
 .. code-block:: shell
 
    mongodrdl --host myhost.example.net:27017 \
@@ -302,7 +302,7 @@ If you are running the |bi-short| on premises and wish to create a
 :ref:`.drdl <drdl>` file from an Atlas database, use the
 following command format:
 
-.. class:: copyable-code
+
 .. code-block:: shell
 
    mongodrdl --host <domain0>.mongodb.net:27017,<domain1>.mongodb.net:27017,... \

--- a/source/reference/mongosqld.txt
+++ b/source/reference/mongosqld.txt
@@ -10,18 +10,14 @@
    :depth: 1
    :class: singlecol
 
-.. only:: html
-
-   .. meta::
-      :description: The mongosqld command man page.
-      :keywords: mongosqld, mongodb, man page
+.. meta::
+   :description: The mongosqld command man page.
+   :keywords: mongosqld, mongodb, man page
 
 Description
 -----------
 
-.. only:: (not man)
-
-   .. binary:: mongosqld
+.. binary:: mongosqld
 
 .. include:: /includes/fact-bi-enterprise.rst
 

--- a/source/reference/mongosqld.txt
+++ b/source/reference/mongosqld.txt
@@ -731,7 +731,7 @@ Example Configuration File
    Linux-specific. Check your local system documentation to
    determine the correct paths for your system.
 
-.. class:: copyable-code
+
 
 .. code-block:: yaml
 
@@ -1017,7 +1017,7 @@ MySQL client to verify the server's identity.
 For *testing* purposes, you can create a ``.pem`` key file named ``test.pem``
 using the ``openssl`` tool:
 
-.. class:: copyable-code
+
 .. code-block:: sh
 
    openssl req -nodes -newkey rsa:2048 -keyout test.key -out test.crt -x509 -days 365 -subj "/C=US/ST=test/L=test/O=test Security/OU=IT Department/CN=test.com"
@@ -1034,7 +1034,7 @@ cluster URI:
 .. note:: Do not specify a username and password in :option:`--mongo-uri`. The
    connection string should only contain the list of servers.
 
-.. class:: copyable-code
+
 .. code-block:: sh
 
    mongosqld --mongo-ssl \
@@ -1048,7 +1048,7 @@ Pass your username, password, and authentication database to your SQL
 client. For example, using ``mysql`` without verifying your :binary:`~bin.mongosqld`
 server certificate:
 
-.. class:: copyable-code
+
 .. code-block:: sh
 
    mysql --host <mongosqld-host> --port <mongosqld-port> -u <username>?source=admin -p --ssl-mode required --enable-cleartext-plugin

--- a/source/reference/mongotranslate.txt
+++ b/source/reference/mongotranslate.txt
@@ -10,18 +10,14 @@
    :depth: 1
    :class: singlecol
 
-.. only:: html
-
-   .. meta::
-      :description: The mongotranslate reference page.
-      :keywords: mongotranslate, mongodb, man page
+.. meta::
+   :description: The mongotranslate reference page.
+   :keywords: mongotranslate, mongodb, man page
 
 Description
 -----------
 
-.. only:: (not man)
-
-   .. binary:: mongotranslate
+.. binary:: mongotranslate
 
 ``mongotranslate`` is a learning tool designed to help users understand
 how SQL queries can be expressed in the MongoDB :manual:`aggregation

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -882,9 +882,8 @@ subqueries and non-equijoins.
   starting index and substring exceeds the length of the
   string.
 
-.. class:: hidden
 
-   .. toctree::
-      :titlesonly:
+.. toctree::
+   :titlesonly:
 
-      /reference/known-issues
+   /reference/known-issues

--- a/source/schema-configuration.txt
+++ b/source/schema-configuration.txt
@@ -22,74 +22,60 @@ see the :binary:`~bin.mongosqld` reference documentation.
 :ref:`bi-cached-sampling`
 -------------------------------------------
 
-.. container:: admonition
-
-   The default sampling mode which :binary:`~bin.mongosqld` uses to
-   analyze your collections and derive a static schema. In this mode,
-   :binary:`~bin.mongosqld` derives the schema on startup and holds the
-   schema in memory.
+The default sampling mode which :binary:`~bin.mongosqld` uses to
+analyze your collections and derive a static schema. In this mode,
+:binary:`~bin.mongosqld` derives the schema on startup and holds the
+schema in memory.
    
 :ref:`bi-persistent-schema`
 ---------------------------------------------------------
 
-.. container:: admonition
-
-   :binary:`~bin.mongosqld` samples your MongoDB collections and
-   creates a schema at the time of startup and writes it to a
-   MongoDB collection. Available via the :option:`--schemaSource
-   <mongosqld --schemaSource>` option.
+:binary:`~bin.mongosqld` samples your MongoDB collections and
+creates a schema at the time of startup and writes it to a
+MongoDB collection. Available via the :option:`--schemaSource
+<mongosqld --schemaSource>` option.
 
 :ref:`Use MongoDB Views <schema-with-views>`
 --------------------------------------------
 
-.. container:: admonition
-
-   :manual:`MongoDB views </core/views/>` allow you to control the
-   display of information from a collection by restricting access
-   to certain fields, renaming fields, sorting data, and other
-   techniques. |bi-short| can read data from a view just as it does
-   from a standard collection.
+:manual:`MongoDB views </core/views/>` allow you to control the
+display of information from a collection by restricting access
+to certain fields, renaming fields, sorting data, and other
+techniques. |bi-short| can read data from a view just as it does
+from a standard collection.
 
 :ref:`Load a Schema from a DRDL File <schema-with-drdl-file>`
 -------------------------------------------------------------
 
-.. container:: admonition
-
-  You can generate a text schema for :binary:`~bin.mongosqld` to use
-  with the :binary:`~bin.mongodrdl` program. You can edit a text
-  schema manually to suit your particular data needs.
+You can generate a text schema for :binary:`~bin.mongosqld` to use
+with the :binary:`~bin.mongodrdl` program. You can edit a text
+schema manually to suit your particular data needs.
 
 :ref:`Resample Schema Data with "FLUSH SAMPLE" <resample-schema-data>`
 ----------------------------------------------------------------------
 
-.. container:: admonition
-
-   If the data in your MongoDB instance changes shape significantly
-   with new fields or collections, you may wish to regenerate the
-   schema |bi-short| uses. You can regenerate the schema either by
-   restarting :binary:`~bin.mongosqld` or by issuing the "FLUSH
-   SAMPLE" command from within the MySQL shell.
+If the data in your MongoDB instance changes shape significantly
+with new fields or collections, you may wish to regenerate the
+schema |bi-short| uses. You can regenerate the schema either by
+restarting :binary:`~bin.mongosqld` or by issuing the "FLUSH
+SAMPLE" command from within the MySQL shell.
 
 :ref:`Geospatial Data <geospatial-data>`
 ----------------------------------------
 
-.. container:: admonition
-
-  |bi-short| handles collections which contain a ``2d`` or ``2dsphere``
-  :manual:`geospatial index </applications/geospatial-indexes>` such
-  that longitude and latitude data are represented within a single
-  table along with other collection data.
+|bi-short| handles collections which contain a ``2d`` or ``2dsphere``
+:manual:`geospatial index </applications/geospatial-indexes>` such
+that longitude and latitude data are represented within a single
+table along with other collection data.
 
 :ref:`type-conflict-resolution`
 -------------------------------
 
-.. container:: admonition
-
-   Relational databases do not allow dynamically typed columns so when
-   the |bi-short| samples data from MongoDB to generate a schema, type
-   conversion conflicts may occur. See this page for more information
-   on how the |bi-short| resolves these conflicts and displays data
-   when conflicts are present.
+Relational databases do not allow dynamically typed columns so when
+the |bi-short| samples data from MongoDB to generate a schema, type
+conversion conflicts may occur. See this page for more information
+on how the |bi-short| resolves these conflicts and displays data
+when conflicts are present.
 
 
 .. toctree::

--- a/source/schema-configuration.txt
+++ b/source/schema-configuration.txt
@@ -91,16 +91,15 @@ see the :binary:`~bin.mongosqld` reference documentation.
    on how the |bi-short| resolves these conflicts and displays data
    when conflicts are present.
 
-.. class:: hidden
 
-   .. toctree::
-      :titlesonly:
+.. toctree::
+   :titlesonly:
 
-      /schema/cached-sampling
-      /schema/persist-schema
-      /schema/use-views
-      /schema/load-schema-from-drdl
-      /schema/resample-schema
-      /schema/geospatial-data
-      /schema/type-conflicts
-      /schema/schema-management-changes
+   /schema/cached-sampling
+   /schema/persist-schema
+   /schema/use-views
+   /schema/load-schema-from-drdl
+   /schema/resample-schema
+   /schema/geospatial-data
+   /schema/type-conflicts
+   /schema/schema-management-changes

--- a/source/tutorial/create-system-dsn.txt
+++ b/source/tutorial/create-system-dsn.txt
@@ -69,7 +69,7 @@ Before creating a :abbr:`DSN (Data Source Name)`, you should:
 
          - Download and extract the {+odbc-driver+} for your platform.
 
-.. _create-system-dsn:
+.. _create-system-dsn-bi-connector:
 
 Procedure
 ---------

--- a/source/tutorial/kerberos.txt
+++ b/source/tutorial/kerberos.txt
@@ -88,8 +88,7 @@ If you have another use case, please contact :website:`MongoDB Support </support
             Set the ``mongosql`` user to delegate for the
             ``mongodb`` user from the ``BI.EXAMPLE.COM`` host.
 
-            .. admonition:: Linux Schema User Authenticating to ADC
-               :class: note
+            .. note:: Linux Schema User Authenticating to ADC
 
                If you are authenticating a user from a Linux host and
                the schema user is using a keytab file instead of a
@@ -148,8 +147,7 @@ If you have another use case, please contact :website:`MongoDB Support </support
                   hostname: <host running mongosqld>
                   serviceName: <name of mongosqld service>
 
-           .. admonition:: Setting Constraints
-              :class: important
+           .. important:: Setting Constraints
 
               - :setting:`security.gssapi.hostname` should match the
                 value in :setting:`serviceName`.
@@ -269,8 +267,7 @@ If you have another use case, please contact :website:`MongoDB Support </support
               ``mongosql@EXAMPLE.COM``
             - Start the MongoDB and |bi| services.
 
-         .. admonition:: Linux Schema User Authenticating to ADC
-            :class: note
+         .. note:: Linux Schema User Authenticating to ADC
 
             If you are authenticating a user from a Linux host and
             your schema user is going to use a username and password,

--- a/source/tutorial/kerberos.txt
+++ b/source/tutorial/kerberos.txt
@@ -153,7 +153,7 @@ If you have another use case, please contact :website:`MongoDB Support </support
                 value in :setting:`serviceName`.
 
               - If you configured Active Directory to use
-                :ms-docs:`constrained delegation </windows-server/security/kerberos/kerberos-constrained-delegation-overview>`,
+                `constrained delegation <https://docs.microsoft.com/en-us/windows-server/security/kerberos/kerberos-constrained-delegation-overview>`__,
                 add :setting:`security.gssapi.constrainedDelegation`
                 ``: true`` to the ``mongosqld`` config file or authentication fails.
 
@@ -387,7 +387,7 @@ If you have another use case, please contact :website:`MongoDB Support </support
            - :setting:`mongodb.net.auth.source`
            - :setting:`mongodb.net.auth.mechanism`
 
-         .. topic:: Testing |bi-short| with Kerberos on ``localhost``
+         .. tip:: Testing |bi-short| with Kerberos on ``localhost``
 
             If you are testing Kerberos with a ``mongosqld`` running
             on a ``localhost``, you must set

--- a/worker.sh
+++ b/worker.sh
@@ -1,2 +1,1 @@
-#!/bin/sh
-make html
+"build-and-stage-next-gen"


### PR DESCRIPTION
Workerpool log: https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=5f4fe51a0636c3a9b68f2e06
Staging: https://docs-mongodborg-staging.corp.mongodb.com/3498fd9/bi-connector/docsworker-xlarge/snooty/

## Notes
- the `container` directive is deprecated -- y'all are using the container directive to indent nested steps, I've filed [DOP-1449](https://jira.mongodb.org/browse/DOP-1449) to look at whether there's a better way for us to do this. All the same, the content is rendering like it did in oldgen, so nothing really to worry about.

- [DOCSP-12086](https://jira.mongodb.org/browse/DOCSP-12086)Broken links - there are a bunch of ambiguous/broken links to settings, options, etc. some of them (e.g. the urioption ones) are broken on the live site as well, so I suspect this is a case of Snooty having better/more thorough error reporting rather than new problems.