### PR TITLE
DOCSP-12075: [BI Connector] Mongosql-auth-c in MacOS Catalina requires OpenSSL v1.0

### DIFF
--- a/source/reference/auth-plugin-c.txt
+++ b/source/reference/auth-plugin-c.txt
@@ -58,6 +58,23 @@ Installing the Plugin
 
      - id: macos
        content: |
+         .. note::
+
+            **macOS Catalina users:**
+
+            The C authentication plugin uses OpenSSL v1.0. If you have
+            OpenSSL v1.1 or greater installed, you must downgrade to v1.0
+            to use the C authentication plugin. You can do so with the
+            following command:
+
+            .. code-block:: none
+
+               brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/30fd2b68feb458656c2da2b91e577960b11c42f4/Formula/openssl.rb
+
+            If you have both versions 1.0 and 1.1 of OpenSSL installed,
+            create a symlink to version 1.0 from ``/usr/local/opt/openssl``
+            and remove the symlink to v1.1.
+
          #. Download the `MySQL 5.7.x installer
             <https://dev.mysql.com/downloads/mysql/>`__ and install the
             MySQL Community Server, which includes the MySQL shell.


### PR DESCRIPTION
[Jira](https://jira.mongodb.org/browse/DOCSP-12075)
[Staged](https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/stevenrenaker/DOCSP-12075/reference/auth-plugin-c.html)