### PR TITLE
DOCSP-13490: [BIC] Missing instruction for installing biconnector as service on RHEL

### DIFF
--- a/source/launch.txt
+++ b/source/launch.txt
@@ -319,6 +319,21 @@ see :ref:`Configuration File <config-format>`. For example:
               bindIp: '127.0.0.1'
               port: 3307
 
+         To install and run ``mongosqld`` as a system service, run the
+         following commands:
+
+         .. code-block:: sh
+
+            sudo mongosqld install --config <pathToConfigFile>/mongosqld.conf
+            sudo systemctl start mongosql.service
+
+         To enable the service so it starts automatically at boot time,
+         run the following:
+
+         .. code-block:: sh
+
+            systemctl enable mongosql.service
+
          RHEL 6.x / CentOS 6.x
          ~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
[Jira](https://jira.mongodb.org/browse/DOCSP-13490)
[Staged](https://docs-mongodbcom-staging.corp.mongodb.com/26ce7af/bi-connector/docsworker-xlarge/DOCSP-13490/launch#launching-mongosqld)