### PR TITLE
(DOCSP-15265) 2.14.3 release notes

### DIFF
--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -56,7 +56,7 @@ Bug Fixes
 Improvements
 ~~~~~~~~~~~~
 
-- Now built with Go 1.5.0.
+- Now built with Go 1.5.0. 
 
 - Adds the Amazon Linux 2 ARM 64 distribution to the download center.
 

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -49,6 +49,10 @@ Bug Fixes
 - Fixes an issue where some queries took longer to complete than in 
   previous versions of |bi-short|. 
 
+- Fixes an issue where the ``listDatabases`` command returned an error 
+  when read preference was set to an analytics node in some sharded 
+  cluster configurations.
+
 Improvements
 ~~~~~~~~~~~~
 

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -20,6 +20,41 @@ Release Notes for |bi|
 .. expect and we don't break the links on the downloads page.
 .. (DOCS-9670 for context)
 
+.. _bi-2-14-3:
+
+|bi| 2.14.3
+-----------
+
+*Released March 23, 2021*
+
+New Features
+~~~~~~~~~~~~
+
+- Enables the use of externally sourced values in configuration files.
+
+- Adds support for the following fields in .yaml configuration files:
+
+  - ``trim``
+  - ``type``
+  - ``digest``
+  - ``digest_key``
+
+Bug Fixes
+~~~~~~~~~
+
+- Fixes an issue where fields with ``null`` values were incorrectly 
+  returned from some queries.
+
+- Fixes an issue where some queries took longer to complete than in 
+  previous versions of |bi-short|. 
+
+Improvements
+~~~~~~~~~~~~
+
+- Now built with Go 1.5.0.
+
+- Adds support for Amazon Linux 2 Arm64.
+
 .. _bi-2-14-2:
 
 |bi| 2.14.2

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -30,7 +30,8 @@ Release Notes for |bi|
 New Features
 ~~~~~~~~~~~~
 
-- Enables the use of externally sourced values in configuration files.
+- Enables the use of externally sourced values in .yaml configuration 
+  files.
 
 - Adds support for the following fields in .yaml configuration files:
 
@@ -42,7 +43,7 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 
-- Fixes an issue where fields with ``null`` values were incorrectly 
+- Fixes an issue where documents with ``null`` values were incorrectly 
   returned from some queries.
 
 - Fixes an issue where some queries took longer to complete than in 
@@ -53,7 +54,7 @@ Improvements
 
 - Now built with Go 1.5.0.
 
-- Adds support for Amazon Linux 2 Arm64.
+- Adds the Amazon Linux 2 ARM 64 distribution to the download center.
 
 .. _bi-2-14-2:
 


### PR DESCRIPTION
[Jira](https://jira.mongodb.org/browse/DOCSP-15265)
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/d3ee190/bi-connector/docsworker-xlarge/DOCSP-15265/release-notes/)

Hi @rychipman, would you please review these release notes whenever you get a moment? 

I left out the following because they don't seem to need release notes, please let me know if any should be included:

- [BI-2335] - IN clause casting mismatch (closed as Won't Fix)
- [BI-2624] - Platforms missing on downloads site
- [BI-2476] - Use macos 10.14 instead of 10.12 for evergreen testing
- [BI-2616] - Stop using mongodbtoolchain
- [BI-2619] - Rely on mongo-tools instead of mongo-tools-common
