### PR TITLE
(DOCSP-17899): remove deprecated crud commands from bi connector docs

### DIFF
--- a/source/includes/geospatial-data.rst
+++ b/source/includes/geospatial-data.rst
@@ -14,7 +14,7 @@ Given the following collection:
 .. code-block:: javascript
 
    db.points.createIndex( { pos : "2dsphere" } )
-   db.points.insert({
+   db.points.insertOne({
        pos : { type: "Point", coordinates: [ -73.97, 40.77 ] },
        name: "Central Park",
        category : "Parks"


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DOCSP-17899)
[Stage](https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/docsworker-xlarge/DOCSP-17889/schema/geospatial-data/)

tested new command:

```
MongoDB Enterprise atlas-wd1p6t-shard-0:PRIMARY>    db.points.insertOne({
...        pos : { type: "Point", coordinates: [ -73.97, 40.77 ] },
...        name: "Central Park",
...        category : "Parks"
...    })
{
	"acknowledged" : true,
	"insertedId" : ObjectId("6112936aa6b0bba12a00cb0c")
}
```