### PR TITLE
(DOCSP-18336) Clarify and generalize BIC configurations

### DIFF
--- a/source/atlas-bi-connector.txt
+++ b/source/atlas-bi-connector.txt
@@ -1,5 +1,7 @@
 :noprevnext:
 
+.. _enable-bi-atlas:
+
 ============================
 Enable BI Connector in Atlas
 ============================
@@ -18,11 +20,11 @@ Enable BI Connector in Atlas
 
 .. include:: /includes/atlas-bi-connector.rst
 
-To install the {+bi-full+} on premises, see the
-:ref:`Installation Guides <installation-guides>`.
-
 .. note::
 
-   You can also deploy the {+bi-full+} to the
+   To install the {+bi-full+} on premises instead, see the
+   :ref:`Installation Guides <installation-guides>`.
+
+   You can also deploy the {+bi-full+} to
    :cloudmgr:`{+cm-full+} </tutorial/deploy-bi-connector/>` or
    :opsmgr:`{+om-full+} </tutorial/deploy-bi-connector/>`.

--- a/source/includes/atlas-bi-connector.rst
+++ b/source/includes/atlas-bi-connector.rst
@@ -1,3 +1,3 @@
-You can host the {+bi-full+} in {+atlas+} To learn how to connect to an
-Atlas-hosted {+bi-short+}, see
+You can host the {+bi-full+} in {+atlas+}. To learn how to enable and 
+connect to an Atlas-hosted {+bi-short+}, see
 :ref:`Connect via {+bi-atlas-short+} <bi-connection>`.

--- a/source/what-is-the-bi-connector.txt
+++ b/source/what-is-the-bi-connector.txt
@@ -72,17 +72,18 @@ local machine, in a data center, or hosted in the cloud.
    :stub-columns: 1
    :widths: 40 30 30
 
-   * - 
-     - |service| database (Hosted)
+   * - |bic-short| configuration
+     - {+atlas-short+} database (Hosted)
      - On-premises database
   
-   * - |service| |bi-short| (Hosted)
-     - Supported for clusters M20 and greater
-     - Not supported
+   * - {+atlas-short+} |bi-short| (Hosted)
+     - :icon:`check`
+       *for clusters M10 and greater
+     -
 
    * - On-premises |bi-short|
-     - Supported
-     - Supported
+     - :icon:`check`
+     - :icon:`check`
 
 
 The following sections describe possible configurations for a

--- a/source/what-is-the-bi-connector.txt
+++ b/source/what-is-the-bi-connector.txt
@@ -54,7 +54,7 @@ BI Connector
   Provides a relational schema and translates |sql|
   queries between your BI tool and MongoDB.
 
-|jdbc| and |odbc| drivers
+|jdbc| or |odbc| drivers
   Provides a standard method to connect to the |bi-short| and MongoDB
   databases from a BI Tool. Depending on what your BI Tool supports, you
   can use |jdbc| and |odbc| drivers to connect to the |bi-short|.
@@ -75,24 +75,18 @@ BI system:
 Hosted Database and |bi-short|
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. note::
-
-   If you don't want to install and manage the |bi-short|, you can use
-   {+atlas+}, our fully-managed database-as-a-service. Databases hosted
-   on {+atlas+} natively support the |bi| and make it easy to start
-   analyzing your data with your preferred BI tools. To get started,
-   :website:`create an {+atlas+} cluster </cloud/atlas/lp/general>`.
-
-In this scenario, the database and |bi-short| applications both run on
-{+atlas+}, and you set up your :doc:`DSN </tutorial/create-system-dsn>`
-with connection information that {+atlas+} provides.
+In this configuration, the database and |bi-short| applications both 
+run on |atlas-short|, MongoDB's fully-managed database-as-a-service. 
+Databases hosted on {+atlas+} natively support the |bi-short|. 
+|atlas-short| provides the connection information for your |jdbc| or 
+|odbc| driver.
 
 .. figure:: /images/bi-connector/components-cloud.jpg
    :alt: Hosted DB and BI Connector
    :figwidth: 700px
    :align: center
 
-Hosted Database and On Premises |bi-short|
+Hosted Database and On-Premises |bi-short|
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you have an {+atlas+} deployment smaller than M10 (including the
@@ -107,13 +101,12 @@ the BI Connector's :doc:`mongosqld process </reference/mongosqld>`.
    :figwidth: 700px
    :align: center
 
-On Premises Database and |bi-short|
+On-Premises Database and |bi-short|
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Your organization may have installations of both MongoDB and |bi-short|
-elsewhere on your network, in which case you can set up your
-:doc:`DSN </tutorial/create-system-dsn>` to point to the |bi-short|
-server address.
+elsewhere on your network, in which case you can set up your |jdbc| or 
+|odbc| driver to connect to the |bi-short| server address.
 
 .. figure:: /images/bi-connector/components-onprem.jpg
    :alt: On Premises DB and BI Connector

--- a/source/what-is-the-bi-connector.txt
+++ b/source/what-is-the-bi-connector.txt
@@ -106,8 +106,9 @@ the |bi-short|.
    You must have an M10 or higher {+atlas+} cluster to enable the 
    built-in |bi-short|.
 
-After :ref:`enabling the BI Connector <enable-bi-atlas>`, {+atlas+} 
-provides the connection information for your |jdbc| or |odbc| driver.
+:ref:`Enable the BI Connector <enable-bi-atlas>` for {+atlas+}, then 
+use the connection information that {+atlas-short+} provides to 
+configure your |jdbc| or |odbc| driver.
 
 .. figure:: /images/bi-connector/components-cloud.jpg
    :alt: Hosted DB and BI Connector

--- a/source/what-is-the-bi-connector.txt
+++ b/source/what-is-the-bi-connector.txt
@@ -35,34 +35,32 @@ The |bi| acts as a layer that translates queries and data between a
 stores no data, and purely serves to bridge your MongoDB cluster with
 business intelligence tools.
 
-.. figure:: /images/bi-connector/components-all.jpg
-   :figwidth: 700px
-   :align: center
-   :alt: Diagram showing that other BI tools communicate with the DSN, which communicates with MongoDB's BI Connector, which in turn communicates with the MongoDB database.
-
 System Components
 -----------------
 
 A complete BI system includes the following components:
 
-MongoDB database
-  Data storage.
-
-BI Connector
-  Provides a relational schema and translates |sql|
-  queries between your BI tool and MongoDB.
+BI Tool
+  Retrieve, visualize, and report on data from a database.
 
 |jdbc| or |odbc| drivers
   Provides a standard method to connect to the |bi-short| and MongoDB
   databases from a BI Tool. Depending on what your BI Tool supports, you
   can use |jdbc| and |odbc| drivers to connect to the |bi-short|.
 
-BI Tool
-  Retrieve, visualize, and report on data from a database.
+BI Connector
+  Provides a relational schema and translates |sql|
+  queries between your BI tool and MongoDB.
 
-Your BI Tool and Driver typically run on your local machine. Your
-database and your |bi-short| instance can run on your local machine,
-in a data center, or hosted in the cloud.
+MongoDB database
+  Data storage.
+
+.. figure:: /images/bi-connector/components-all.jpg
+   :figwidth: 700px
+   :align: center
+   :alt: Diagram showing that other BI tools communicate with the DSN, which communicates with MongoDB's BI Connector, which in turn communicates with the MongoDB database.
+
+Your **BI Tool** and **Driver** typically run on your local machine. Your **database** and your **{+bi-short+} instance** can run on your local machine, in a data center, or hosted in the cloud.
 
 |bi-short| Configurations
 -------------------------

--- a/source/what-is-the-bi-connector.txt
+++ b/source/what-is-the-bi-connector.txt
@@ -68,7 +68,7 @@ local machine, in a data center, or hosted in the cloud.
 -------------------------
 
 The following table outlines the supported configurations for the 
-|bi-short| and MongoDB database:
+|bi-short| and MongoDB database deployment:
 
 .. list-table::
    :header-rows: 1
@@ -76,14 +76,10 @@ The following table outlines the supported configurations for the
    :widths: 40 30 30
 
    * - |bi-short| configuration
-     - {+atlas-short+} database support
-
-       *Cloud hosted*
-     - On-premises database support
+     - {+atlas-short+} database (hosted)
+     - On-premises database
   
-   * - {+atlas-short+} |bi-short|
-
-       *Cloud hosted*
+   * - {+atlas-short+} |bi-short| (hosted)
      - :icon:`check`
 
        *Clusters M10 and greater only*

--- a/source/what-is-the-bi-connector.txt
+++ b/source/what-is-the-bi-connector.txt
@@ -76,10 +76,14 @@ The following table outlines the supported configurations for the
    :widths: 40 30 30
 
    * - |bi-short| configuration
-     - {+atlas-short+} database (Hosted)
-     - On-premises database
+     - {+atlas-short+} database support
+
+       *Cloud hosted*
+     - On-premises database support
   
-   * - {+atlas-short+} |bi-short| (Hosted)
+   * - {+atlas-short+} |bi-short|
+
+       *Cloud hosted*
      - :icon:`check`
 
        *Clusters M10 and greater only*

--- a/source/what-is-the-bi-connector.txt
+++ b/source/what-is-the-bi-connector.txt
@@ -67,17 +67,42 @@ local machine, in a data center, or hosted in the cloud.
 |bi-short| Configurations
 -------------------------
 
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+   :widths: 40 30 30
+
+   * - 
+     - |service| database (Hosted)
+     - On-premises database
+  
+   * - |service| |bi-short| (Hosted)
+     - Supported for clusters M20 and greater
+     - Not supported
+
+   * - On-premises |bi-short|
+     - Supported
+     - Supported
+
+
 The following sections describe possible configurations for a
 BI system:
 
 Hosted Database and |bi-short|
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In this configuration, the database and |bi-short| applications both 
-run on {+atlas+}, MongoDB's fully-managed database-as-a-service. 
-Databases hosted on {+atlas+} natively support the |bi-short|. 
-{+atlas+} provides the connection information for your |jdbc| or 
-|odbc| driver.
+In this configuration, your database and |bi-short| 
+applications both run on {+atlas+}, MongoDB's fully-managed 
+database-as-a-service. Databases hosted on {+atlas+} natively support 
+the |bi-short|.
+
+.. note::
+
+   You must have an M10 or higher {+atlas+} cluster to enable the 
+   built-in |bi-short|.
+
+After :ref:`enabling the BI Connector <enable-bi-atlas>`, {+atlas+} 
+provides the connection information for your |jdbc| or |odbc| driver.
 
 .. figure:: /images/bi-connector/components-cloud.jpg
    :alt: Hosted DB and BI Connector
@@ -87,12 +112,13 @@ Databases hosted on {+atlas+} natively support the |bi-short|.
 Hosted Database and On-Premises |bi-short|
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you have a {+atlas+} deployment smaller than M10 (including the
-{+atlas+} :atlas:`free tier </getting-started/>`), or if your MongoDB
-instance is not hosted on {+atlas+}, you can run |bi-short| locally and
-specify a remote database address with the
-:option:`--mongo-uri <mongosqld --mongo-uri>` option when you start
-the BI Connector's :doc:`mongosqld process </reference/mongosqld>`.
+In this configuration, your MongoDB database runs on any 
+internet-accessible host, including any tier of {+atlas+} cluster, and 
+your |bi-short| runs locally.
+
+:ref:`Install <installation-guides>` and :ref:`launch <launch>` the 
+|bi-short|, specifying a remote database address, then configure your 
+|jdbc| or |odbc| driver to connect to the |bi-short|.
 
 .. figure:: /images/bi-connector/components-onprem-bi-atlas.jpg
    :alt: On Premises DB and Local BI Connector
@@ -102,9 +128,12 @@ the BI Connector's :doc:`mongosqld process </reference/mongosqld>`.
 On-Premises Database and |bi-short|
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Your organization might have installations of both MongoDB and 
-|bi-short| elsewhere on your network, in which case you can set up your 
-|jdbc| or |odbc| driver to connect to the |bi-short| server address.
+In this configuration, the database and |bi-short| applications both 
+run on-premises, either locally or on your network. 
+
+:ref:`Install <installation-guides>` and :ref:`launch <launch>` the 
+|bi-short|, then configure your |jdbc| or |odbc| driver to connect to 
+the |bi-short| server address.
 
 .. figure:: /images/bi-connector/components-onprem.jpg
    :alt: On Premises DB and BI Connector

--- a/source/what-is-the-bi-connector.txt
+++ b/source/what-is-the-bi-connector.txt
@@ -148,7 +148,7 @@ Local Database and |bi-short|
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For testing and all-in-one-box local experimentation, you can run
-MongoDB and |bi-short| on your desktop. This configuration might be 
+MongoDB and the |bi-short| on your desktop. This configuration might be 
 helpful for proofs of concept or as a way to explore the possibilities 
 of data visualization with the |bi-short|.
 

--- a/source/what-is-the-bi-connector.txt
+++ b/source/what-is-the-bi-connector.txt
@@ -68,7 +68,7 @@ local machine, in a data center, or hosted in the cloud.
 -------------------------
 
 The following table outlines the supported configurations for the 
-|bi-short| and MongoDB database deployment:
+|bi-short| and MongoDB database deployments:
 
 .. list-table::
    :header-rows: 1
@@ -148,9 +148,9 @@ Local Database and |bi-short|
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For testing and all-in-one-box local experimentation, you can run
-MongoDB and |bi-short| on your desktop. This is the simplest
-configuration, perfect for quickly looking over the possibilities for
-data visualization with |bi-short|.
+MongoDB and |bi-short| on your desktop. This configuration might be 
+helpful for proofs of concept or as a way to explore the possibilities 
+of data visualization with the |bi-short|.
 
 Learn more about setting up a local |bi-short| test installation
 in the :doc:`Quick Start Guide </local-quickstart>`.

--- a/source/what-is-the-bi-connector.txt
+++ b/source/what-is-the-bi-connector.txt
@@ -2,9 +2,9 @@
 
 .. _bi-connector:
 
-====================================
-What is the MongoDB Connector for BI
-====================================
+=====================================
+What is the MongoDB Connector for BI?
+=====================================
 
 .. default-domain:: mongodb
 
@@ -46,7 +46,7 @@ BI Tool
 |jdbc| or |odbc| drivers
   Provides a standard method to connect to the |bi-short| and MongoDB
   databases from a BI Tool. Depending on what your BI Tool supports, you
-  can use |jdbc| and |odbc| drivers to connect to the |bi-short|.
+  can use |jdbc| or |odbc| drivers to connect to the |bi-short|.
 
 BI Connector
   Provides a relational schema and translates |sql|
@@ -60,7 +60,9 @@ MongoDB database
    :align: center
    :alt: Diagram showing that other BI tools communicate with the DSN, which communicates with MongoDB's BI Connector, which in turn communicates with the MongoDB database.
 
-Your **BI Tool** and **Driver** typically run on your local machine. Your **database** and your **{+bi-short+} instance** can run on your local machine, in a data center, or hosted in the cloud.
+Your **BI Tool** and **Driver** typically run on your local machine. 
+Your **{+bi-short+} instance** and your **database** can run on your 
+local machine, in a data center, or hosted in the cloud.
 
 |bi-short| Configurations
 -------------------------

--- a/source/what-is-the-bi-connector.txt
+++ b/source/what-is-the-bi-connector.txt
@@ -67,18 +67,22 @@ local machine, in a data center, or hosted in the cloud.
 |bi-short| Configurations
 -------------------------
 
+The following table outlines the supported configurations for the 
+|bi-short| and MongoDB database:
+
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
    :widths: 40 30 30
 
-   * - |bic-short| configuration
+   * - |bi-short| configuration
      - {+atlas-short+} database (Hosted)
      - On-premises database
   
    * - {+atlas-short+} |bi-short| (Hosted)
      - :icon:`check`
-       *for clusters M10 and greater
+
+       *Clusters M10 and greater only*
      -
 
    * - On-premises |bi-short|

--- a/source/what-is-the-bi-connector.txt
+++ b/source/what-is-the-bi-connector.txt
@@ -89,9 +89,7 @@ The following table outlines the supported configurations for the
      - :icon:`check`
      - :icon:`check`
 
-
-The following sections describe possible configurations for a
-BI system:
+The following sections describe these configurations:
 
 Hosted Database and |bi-short|
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/what-is-the-bi-connector.txt
+++ b/source/what-is-the-bi-connector.txt
@@ -14,8 +14,6 @@ What is the MongoDB Connector for BI
    :depth: 2
    :class: singlecol
 
-.. include:: /includes/fact-bi-enterprise.rst
-
 Traditional business intelligence tools work with flat, tabular data.
 These tools aren't sophisticated enough to understand three-dimensional
 data stored in MongoDB databases.
@@ -76,9 +74,9 @@ Hosted Database and |bi-short|
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In this configuration, the database and |bi-short| applications both 
-run on |atlas-short|, MongoDB's fully-managed database-as-a-service. 
+run on {+atlas+}, MongoDB's fully-managed database-as-a-service. 
 Databases hosted on {+atlas+} natively support the |bi-short|. 
-|atlas-short| provides the connection information for your |jdbc| or 
+{+atlas+} provides the connection information for your |jdbc| or 
 |odbc| driver.
 
 .. figure:: /images/bi-connector/components-cloud.jpg

--- a/source/what-is-the-bi-connector.txt
+++ b/source/what-is-the-bi-connector.txt
@@ -8,6 +8,12 @@ What is the MongoDB Connector for BI
 
 .. default-domain:: mongodb
 
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
 .. include:: /includes/fact-bi-enterprise.rst
 
 Traditional business intelligence tools work with flat, tabular data.
@@ -60,11 +66,14 @@ Your BI Tool and Driver typically run on your local machine. Your
 database and your |bi-short| instance can run on your local machine,
 in a data center, or hosted in the cloud.
 
+|bi-short| Configurations
+-------------------------
+
 The following sections describe possible configurations for a
-BI system.
+BI system:
 
 Hosted Database and |bi-short|
-------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. note::
 
@@ -84,7 +93,7 @@ with connection information that {+atlas+} provides.
    :align: center
 
 Hosted Database and On Premises |bi-short|
-------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you have an {+atlas+} deployment smaller than M10 (including the
 {+atlas+} :atlas:`free tier </getting-started/>`), or if your MongoDB
@@ -99,7 +108,7 @@ the BI Connector's :doc:`mongosqld process </reference/mongosqld>`.
    :align: center
 
 On Premises Database and |bi-short|
------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Your organization may have installations of both MongoDB and |bi-short|
 elsewhere on your network, in which case you can set up your
@@ -112,7 +121,7 @@ server address.
    :align: center
 
 Local Database and |bi-short|
------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For testing and all-in-one-box local experimentation, you can run
 MongoDB and |bi-short| on your desktop. This is the simplest

--- a/source/what-is-the-bi-connector.txt
+++ b/source/what-is-the-bi-connector.txt
@@ -40,10 +40,10 @@ System Components
 
 A complete BI system includes the following components:
 
-BI Tool
+BI tool
   Retrieve, visualize, and report on data from a database.
 
-|jdbc| or |odbc| drivers
+|jdbc| or |odbc| driver
   Provides a standard method to connect to the |bi-short| and MongoDB
   databases from a BI Tool. Depending on what your BI Tool supports, you
   can use |jdbc| or |odbc| drivers to connect to the |bi-short|.
@@ -60,7 +60,7 @@ MongoDB database
    :align: center
    :alt: Diagram showing that other BI tools communicate with the DSN, which communicates with MongoDB's BI Connector, which in turn communicates with the MongoDB database.
 
-Your **BI Tool** and **Driver** typically run on your local machine. 
+Your **BI tool** and **driver** typically run on your local machine. 
 Your **{+bi-short+} instance** and your **database** can run on your 
 local machine, in a data center, or hosted in the cloud.
 
@@ -87,7 +87,7 @@ Databases hosted on {+atlas+} natively support the |bi-short|.
 Hosted Database and On-Premises |bi-short|
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you have an {+atlas+} deployment smaller than M10 (including the
+If you have a {+atlas+} deployment smaller than M10 (including the
 {+atlas+} :atlas:`free tier </getting-started/>`), or if your MongoDB
 instance is not hosted on {+atlas+}, you can run |bi-short| locally and
 specify a remote database address with the
@@ -102,9 +102,9 @@ the BI Connector's :doc:`mongosqld process </reference/mongosqld>`.
 On-Premises Database and |bi-short|
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Your organization may have installations of both MongoDB and |bi-short|
-elsewhere on your network, in which case you can set up your |jdbc| or 
-|odbc| driver to connect to the |bi-short| server address.
+Your organization might have installations of both MongoDB and 
+|bi-short| elsewhere on your network, in which case you can set up your 
+|jdbc| or |odbc| driver to connect to the |bi-short| server address.
 
 .. figure:: /images/bi-connector/components-onprem.jpg
    :alt: On Premises DB and BI Connector


### PR DESCRIPTION
[Ticket](https://jira.mongodb.org/browse/DOCSP-18336)
[Staged](https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/docsworker-xlarge/DOCSP-18336/what-is-the-bi-connector/)

Note for copy review: this is mostly moving things around. The small amount of new copy is in the BI configuration descriptions, everything else is just switching the order or removing things.

- Moved the configuration types under an umbrella header and added a ToC to the page to better group and distinguish them from the rest of the page.
- Changed mentions of ODBC/ creating a DSN for ODBC to more general statements about connecting with ODBC or JDBC.
- Reorganized the Components section. Screenshot now appears under the components, component order changed to match.
- In order to reduce note clutter, I removed the marketing-slanted callout to use Atlas and moved the important information into the body of that configuration - still highlighting the ease of the Atlas configuration. 
- Also to reduce note clutter, I removed the top note that says BIC is compatible with all current MongoDB server versions. That note is used on many other pages as well, and while I think it's worth specifically calling out, I don't think it needs to be addressed at the top of the intro page; I think users will assume our BIC is compatible with the server.