### PR TITLE
(DOCSP-23677) Updates Mac install instructions to use zip archive

### DIFF
--- a/source/includes/steps-install-bi-connector-macos.yaml
+++ b/source/includes/steps-install-bi-connector-macos.yaml
@@ -11,18 +11,28 @@ ref: install-bi-mac
 level: 4
 content: |
 
-  a. Extract the downloaded ``.tar`` archive.
+  a. Extract the downloaded ``.zip`` archive. Replace {SOURCE-PATH} with
+     the path to the directory where you downloaded the ``.zip``
+     archive. Replace {DESTINATION-PATH} with the path to the directory
+     where you want to extract the archive.
 
      
      .. code-block:: sh
 
-        tar -xvzf mongodb-bi-osx-x86_64-{version}.tgz
+        unzip {SOURCE-PATH}/mongodb-bi-osx-x86_64-{version}.zip -d {DESTINATION-PATH}
 
-  b. Install the programs within the ``bin/`` directory into a directory
+  b. Change to the ``mongodb-bi-osx-x86_64-{version}`` directory.
+     Replace {DESTINATION-PATH} with the path to the directory
+     where you extracted the archive in the previous step.
+
+     .. code-block:: sh
+
+        cd {DESTINATION-PATH}/mongodb-bi-osx-x86_64-{version}/
+  
+  c. Install the programs within the ``bin/`` directory into a directory
      listed in your system ``PATH``. If a prior version exists, 
      overwrite the binaries.
 
-     
      .. code-block:: sh
 
         sudo install -m755 bin/mongo* /usr/local/bin/


### PR DESCRIPTION
[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6356aca37f102f5cea12b05a)
[Jira Ticket](https://jira.mongodb.org/browse/DOCSP-23677)
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/docsworker-xlarge/DOCSP-23677/tutorial/install-bi-connector-macos/#install-the-bi-short)

I tested this code myself and confirmed that it works on my Mac.