### PR TITLE
(DOCSP-26278): Added release note item for removed support.

### DIFF
--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -40,7 +40,7 @@ Behavioral Changes
 - Adds Debian 11 support. 
 - Adds Enterprise RHEL 8 zSeries support.
 - Removes all zSeries/IBM POWER PC platforms support except for RHEL 8 zSeries.
-- Removes RHEL 6 and RHEL 7 on S390x support.
+- Removes RHEL 6.x/7.x on S390x support.
 
 .. _bi-2-14-4:
 

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -40,6 +40,7 @@ Behavioral Changes
 - Adds Debian 11 support. 
 - Adds Enterprise RHEL 8 zSeries support.
 - Removes all zSeries/IBM POWER PC platforms support except for RHEL 8 zSeries.
+- Removes RHEL 6 and RHEL 7 on S390x support.
 
 .. _bi-2-14-4:
 


### PR DESCRIPTION
@JuliaMongo, I added a release note item for the removed support for RHEL6/7 on S390x.

[STAGE](https://docs-mongodbcom-staging.corp.mongodb.com/bi-connector/docsworker-xlarge/DOCSP-26278/release-notes/)

[JIRA](https://jira.mongodb.org/browse/DOCSP-26278)

[BUILD](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=636c02707f102f5ceaf82173)