### PR TITLE
(DOCS-12116) update default file permission from 448 to 0700

### DIFF
--- a/source/includes/options/option-mongosqld-filePermissions.rst
+++ b/source/includes/options/option-mongosqld-filePermissions.rst
@@ -1,6 +1,6 @@
 .. option:: --filePermissions <mode>
 
-   *Default*: 448
+   *Default*: 0700
 
    Specify the permissions for the Unix domain socket file.
 


### PR DESCRIPTION
Update default file permission from 448 to 0700.

Slack thread for reference: https://mongodb.enterprise.slack.com/archives/C0V5DQ8KD/p1702938349479769

[JIRA](https://jira.mongodb.org/browse/DOCS-12116)
[BUILD](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6580cbdc7a5cb5fef56b5105)
[STAGING](https://preview-mongodbjvincentmongodb.gatsbyjs.io/bi-connector/DOCS-12116/reference/mongosqld/#socket-options)