### PR TITLE
DOCSP-35199 jdbc link fixes

### DIFF
--- a/source/reference/jdbc-driver.txt
+++ b/source/reference/jdbc-driver.txt
@@ -14,8 +14,8 @@ The {+bi-full+} uses the `MySQL Connector/J
 for |jdbc| connectivity.
 
 You must use a MySQL Connector/J version from the 5.1.x series with the
-|bi-short|. The minimum supported version is `5.1.49 
-<https://mvnrepository.com/artifact/mysql/mysql-connector-java/5.1.49>`__.
+|bi-short|. The minimum supported version is `5.1.44 
+<https://mvnrepository.com/artifact/mysql/mysql-connector-java/5.1.44>`__.
 
 .. important::
 

--- a/source/reference/jdbc-driver.txt
+++ b/source/reference/jdbc-driver.txt
@@ -10,12 +10,12 @@
 
 
 The {+bi-full+} uses the `MySQL Connector/J
-<https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-installing.html>`__
+<https://dev.mysql.com/doc/connector-j/en/connector-j-installing.html>`__
 for |jdbc| connectivity.
 
 You must use a MySQL Connector/J version from the 5.1.x series with the
-|bi-short|. The minimum supported version is `5.1.39 
-<https://mvnrepository.com/artifact/mysql/mysql-connector-java/5.1.39>`__.
+|bi-short|. The minimum supported version is `5.1.49 
+<https://mvnrepository.com/artifact/mysql/mysql-connector-java/5.1.49>`__.
 
 .. important::
 


### PR DESCRIPTION
Updated both links on the JDBC page. 

And from [this BI ticket](https://jira.mongodb.org/browse/BI-2838), I also updated the minimum version to 5.1.44

[JIRA](https://jira.mongodb.org/browse/DOCSP-35199)
[Staging](https://preview-mongodbkyuanmongodb.gatsbyjs.io/bi-connector/DOCSP-35199/reference/jdbc-driver/)
[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65a7f535dcc0144a5153265e)