### PR TITLE
Docsp 36779

### DIFF
--- a/source/reference/mongodrdl.txt
+++ b/source/reference/mongodrdl.txt
@@ -11,8 +11,7 @@
    :class: singlecol
 
 .. meta::
-   :description: The mongodrdl command man page.
-   :keywords: mongodrdl, mongodb, man page
+   :description: The mongodrdl command reference page.
 
 Description
 -----------

--- a/source/reference/mongosqld.txt
+++ b/source/reference/mongosqld.txt
@@ -11,8 +11,7 @@
    :class: singlecol
 
 .. meta::
-   :description: The mongosqld command man page.
-   :keywords: mongosqld, mongodb, man page
+   :description: The mongosqld command reference page.
 
 Description
 -----------

--- a/source/reference/mongotranslate.txt
+++ b/source/reference/mongotranslate.txt
@@ -12,7 +12,6 @@
 
 .. meta::
    :description: The mongotranslate reference page.
-   :keywords: mongotranslate, mongodb, man page
 
 Description
 -----------

--- a/source/reference/mongotranslate.txt
+++ b/source/reference/mongotranslate.txt
@@ -13,6 +13,7 @@
 .. meta::
    :description: The mongotranslate reference page.
 
+
 Description
 -----------
 

--- a/source/reference/mongotranslate.txt
+++ b/source/reference/mongotranslate.txt
@@ -13,7 +13,6 @@
 .. meta::
    :description: The mongotranslate reference page.
 
-
 Description
 -----------
 


### PR DESCRIPTION
### JIRA
https://jira.mongodb.org/browse/DOCSP-36779

### Description
The Smartling translation software is reading page metadata, and these metadata tags are causing problems.
`man page`