### PR TITLE
Remove duplicate constant in `snooty.toml`

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -28,7 +28,6 @@ odbc-driver-name = "MongoDB BI Connector ODBC Driver"
 odbc-driver = "`MongoDB BI Connector ODBC Driver <https://github.com/mongodb/mongo-bi-connector-odbc-driver/releases/>`__"
 jdbc-driver = "MySQL JDBC Driver"
 om-full = "MongoDB Ops Manager"
-cm-full = "MongoDB Cloud Manager"
 
 [substitutions]
 ent-build = "MongoDB Enterprise"


### PR DESCRIPTION
In testing Autobuilder release, we noticed that this branch will fail because there is a duplicate constant.