### PR TITLE
DOCSP-35411 -- Add workaround for 'Mapping Potentially Null Values at Different Object Depths' to Known Issues.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "esbonio.sphinx.confDir": ""
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "esbonio.sphinx.confDir": ""
-}

--- a/source/reference.txt
+++ b/source/reference.txt
@@ -13,4 +13,5 @@ Reference
    /reference/type-conversion
    /reference/user-authorization
    /reference/system-variables
+   /reference/known-issues
    /supported-operations

--- a/source/reference/known-issues.txt
+++ b/source/reference/known-issues.txt
@@ -68,3 +68,21 @@ Given the exact same |sql| query, the |bi-short| does not return
       GROUP BY class;
       
       Empty set (0.00 sec)
+
+
+Mapping Maybe-nulls at Different Object Depths
+----------------------------------------------
+A known mapping error occurs when an array field is sometimes ``NULL`` 
+and a field within that array field is also sometimes ``NULL``. A workaround
+for this error is to include the ``nonnullsched`` parameter.
+
+.. example::
+
+   For a collection named ``nextDeparture`` with an array field that is 
+   sometimes ``NULL`` called ``response.sechedule``, we can create the 
+   following view:
+
+   .. code-block:: javascript
+
+      db.createView('nonullsched', '"nextDeparture"',  [{'$match': {'response.schedule': {'$type': 'array'}}}])
+

--- a/source/reference/known-issues.txt
+++ b/source/reference/known-issues.txt
@@ -74,8 +74,8 @@ BI Connector Returns ``NULL`` Values due to Mapping Error
 ----------------------------------------------------------
 
 A known mapping error can occur that causes all returned values to be ``NULL`` 
-in the result. This error occurs when you query a collection in which documents
-contain an array field that can be ``NULL``, and the same array contains 
+in the result. This error occurs when you query a collection that
+contains an array field that can be ``NULL``, and the same array contains 
 an additional field that can also be ``NULL``. A workaround for this error is to 
 create a view by including the ``nonnullsched`` parameter with the ``createView`` method.
 

--- a/source/reference/known-issues.txt
+++ b/source/reference/known-issues.txt
@@ -70,11 +70,13 @@ Given the exact same |sql| query, the |bi-short| does not return
       Empty set (0.00 sec)
 
 
-Mapping Maybe-nulls at Different Object Depths
-----------------------------------------------
-A known mapping error occurs when an array field is sometimes ``NULL`` 
-and a field within that array field is also sometimes ``NULL``. A workaround
-for this error is to include the ``nonnullsched`` parameter.
+Mapping Potentially Null Values at Different Object Depths
+----------------------------------------------------------
+A known mapping error can occur that causes all returned values to be ``NULL`` 
+in the result. This error occurs when you query a collection in which documents
+contain an array field that can be ``NULL`` and that array contains a 
+field that can also be ``NULL``. A workaround for this error is to 
+include the ``nonnullsched`` parameter with the ``createView`` method.
 
 .. example::
 

--- a/source/reference/known-issues.txt
+++ b/source/reference/known-issues.txt
@@ -91,4 +91,3 @@ is not ``NULL``.
    .. code-block:: javascript
 
       db.createView('nonullsched', '"nextDeparture"',  [{'$match': {'response.schedule': {'$type': 'array'}}}])
-

--- a/source/reference/known-issues.txt
+++ b/source/reference/known-issues.txt
@@ -75,7 +75,7 @@ Mapping Potentially Null Values at Different Object Depths
 A known mapping error can occur that causes all returned values to be ``NULL`` 
 in the result. This error occurs when you query a collection in which documents
 contain an array field that can be ``NULL`` and that array contains a 
-field that can also be ``NULL``. A workaround for this error is to 
+an additional field that can also be ``NULL``. A workaround for this error is to 
 include the ``nonnullsched`` parameter with the ``createView`` method.
 
 .. example::

--- a/source/reference/known-issues.txt
+++ b/source/reference/known-issues.txt
@@ -74,7 +74,7 @@ Mapping Potentially Null Values at Different Object Depths
 ----------------------------------------------------------
 A known mapping error can occur that causes all returned values to be ``NULL`` 
 in the result. This error occurs when you query a collection in which documents
-contain an array field that can be ``NULL`` and that array contains a 
+contain an array field that can be ``NULL`` and that array contains 
 an additional field that can also be ``NULL``. A workaround for this error is to 
 include the ``nonnullsched`` parameter with the ``createView`` method.
 

--- a/source/reference/known-issues.txt
+++ b/source/reference/known-issues.txt
@@ -70,14 +70,17 @@ Given the exact same |sql| query, the |bi-short| does not return
       Empty set (0.00 sec)
 
 
-BI Connector Returns ``NULL`` Values due to Mapping Error
+BI Connector Returns ``NULL`` Values Due to Mapping Error
 ----------------------------------------------------------
 
-A known mapping error can occur that causes all returned values to be ``NULL`` 
-in the result. This error occurs when you query a collection that
+A known mapping error can occur that causes |bi-short| to return all ``NULL`` 
+values. This error occurs when you query a collection that
 contains an array field that can be ``NULL``, and the same array contains 
 an additional field that can also be ``NULL``. A workaround for this error is to 
-create a view by including the ``nonnullsched`` parameter with the ``createView`` method.
+create a view by including the ``nonnullsched`` parameter with the 
+``createView`` method, which will only return documents in which the array 
+is not ``NULL``.
+
 
 .. example::
 

--- a/source/reference/known-issues.txt
+++ b/source/reference/known-issues.txt
@@ -77,9 +77,8 @@ A known mapping error can occur that causes |bi-short| to return all ``NULL``
 values. This error occurs when you query a collection that
 contains an array field that can be ``NULL``, and the same array contains 
 an additional field that can also be ``NULL``. A workaround for this error is to 
-create a view by including the ``nonnullsched`` parameter with the 
-``createView`` method, which will only return documents in which the array 
-is not ``NULL``.
+create a view with the ``$match`` filter that only returns documents in which 
+the field ``$type`` is ``array`` with the ``createView`` method.
 
 
 .. example::

--- a/source/reference/known-issues.txt
+++ b/source/reference/known-issues.txt
@@ -70,19 +70,20 @@ Given the exact same |sql| query, the |bi-short| does not return
       Empty set (0.00 sec)
 
 
-Mapping Potentially Null Values at Different Object Depths
+BI Connector Returns ``NULL`` Values due to Mapping Error
 ----------------------------------------------------------
+
 A known mapping error can occur that causes all returned values to be ``NULL`` 
 in the result. This error occurs when you query a collection in which documents
-contain an array field that can be ``NULL`` and that array contains 
+contain an array field that can be ``NULL``, and the same array contains 
 an additional field that can also be ``NULL``. A workaround for this error is to 
-include the ``nonnullsched`` parameter with the ``createView`` method.
+create a view by including the ``nonnullsched`` parameter with the ``createView`` method.
 
 .. example::
 
-   For a collection named ``nextDeparture`` with an array field that is 
-   sometimes ``NULL`` called ``response.sechedule``, we can create the 
-   following view:
+   For a collection named ``nextDeparture`` with an array field named 
+   ``response.schedule`` that is sometimes ``NULL``, you can create 
+   the following view:
 
    .. code-block:: javascript
 


### PR DESCRIPTION
Add workaround for 'Mapping Potentially Null Values at Different Object Depths' to Known Issues.

[JIRA](https://jira.mongodb.org/browse/DOCSP-35411)
[BUILD](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65de1f3e7111165982c96410)
[STAGING](https://preview-mongodbjvincentmongodb.gatsbyjs.io/bi-connector/DOCSP-35411/reference/known-issues/#mapping-potentially-null-values-at-different-object-depths)