### PR TITLE
DOCS-15921 macOS catalina warning update

### DIFF
--- a/source/includes/temp-warn-odbc-catalina.rst
+++ b/source/includes/temp-warn-odbc-catalina.rst
@@ -3,6 +3,6 @@
 .. important::
 
    The 1.0.16 edition of ODBC Manager included with the {+odbc-driver+} 
-   is not compatible with macOS Catalina. If you are on
-   Catalina, download and install the 
+   is not compatible with macOS Catalina or later versions of macOS. If
+   you are on Catalina or a later version of macOS, download and install the 
    `latest version (1.0.19) of ODBC manager. <http://www.odbcmanager.net/index.php>`__


### PR DESCRIPTION
Updated the macOS catalina warning to also mention it won't work for future macOS versions.

[JIRA](https://jira.mongodb.org/browse/DOCS-15921)
[Staging](https://preview-mongodbkyuanmongodb.gatsbyjs.io/bi-connector/DOCS-15921/reference/odbc-driver/#supported-platforms)
[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65ea3ed66fc5f048506b85be)