### PR TITLE
(DOCSP-40367) cannot use drdl file in Atlas BIC

### DIFF
--- a/source/reference/mongodrdl.txt
+++ b/source/reference/mongodrdl.txt
@@ -293,9 +293,12 @@ the provisioning of dedicated servers for MongoDB instances.
 
 .. note::
 
-   MongoDB Atlas now offers a hosted |bi-short| and does not
-   require a :ref:`.drdl <drdl>` file. For more information on the
-   Atlas-hosted |bi-short|, see :ref:`bi-connection`.
+   MongoDB Atlas offers a hosted |bi-short|. You can't use the ``.drdl``
+   file output of the ``mongodrdl`` command in the Atlas-hosted |bi-short|.
+   Atlas |bi-short| requires sampling that has an adjustable sample
+   refresh interval and sample size.
+
+   For more information on the Atlas-hosted |bi-short|, see :ref:`bi-connection`.
 
 If you are running the |bi-short| locally and wish to create a
 :ref:`.drdl <drdl>` file from an Atlas database, use the


### PR DESCRIPTION
This PR adds a note that .drdl file can't be used in Atlas BI Connector. 
It is similar to an Atlas-side PR on the same.

[DOCSP-40367](https://jira.mongodb.org/browse/DOCSP-40367)

[Staging](https://preview-mongodbjuliamongo.gatsbyjs.io/bi-connector/DOCSP-40367/reference/mongodrdl/#mongodb-atlas-example:~:text=MongoDB%20Atlas%20offers%20a%20hosted%20BI%20Connector.%20You%20can%27t%20use%20the%20.drdl%20file%20output%20of%20the%20mongodrdl%20command%20in%20the%20Atlas%2Dhosted%20BI%20Connector.%20Atlas%20BI%20Connector%20requires%20sampling%20that%20has%20an%20adjustable%20sample%20refresh%20interval%20and%20sample%20size.)

[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=666bbc79ebce19f314bff41f)