### PR TITLE
DOCSP-43801 added bic v2.14.13 rn

### DIFF
--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -20,6 +20,29 @@ Release Notes for |bi|
 .. expect and we don't break the links on the downloads page.
 .. (DOCS-9670 for context)
 
+.. _bi-2-14-13:
+
+|bi| 2.14.13
+------------
+
+*Released June 13th, 2024*
+
+Improvements
+~~~~~~~~~~~~
+
+- Updates the packaging on Windows.
+- Upgrades ``golang.org/x/crypto`` from ``v0.8.0`` to ``v0.17.0``.
+- Introduces the following SSDLC policy updates:
+  
+  - Adds SBOM Lite support.
+  - Integrates Silk vulnerability scanning.
+  - |bi| generates and publishes a public third-party dependency report.
+
+Bug Fixes
+~~~~~~~~~
+
+- Fixes a bug where |bi| sampling stalled due to aggregate error.
+
 .. _bi-2-14-12:
 
 |bi| 2.14.12


### PR DESCRIPTION
Added the v2.14.13 release notes.

[JIRA](https://jira.mongodb.org/browse/DOCSP-43801)
[Staging](https://deploy-preview-444--mongodb-docs-bi-connector.netlify.app/release-notes/#bi-2.14.13)