### PR TITLE
(DOCSP-44175) Fixes final important nested components for BIC

### DIFF
--- a/source/includes/steps-create-system-dsn-auth-macos.rst
+++ b/source/includes/steps-create-system-dsn-auth-macos.rst
@@ -43,11 +43,9 @@ a. Launch ODBC Manager.
       * - **SERVER**
         - The hostname or IP address of the |bi| host.
 
-          .. important::
-
-             Use ``127.0.0.1`` to connect via TCP to localhost.
-             Specifying a value other than an IP address, will attempt to
-             connect via Unix socket.
+          :gold:`IMPORTANT:` Use ``127.0.0.1`` to connect using TCP to
+          localhost. If you specify a value other than an IP address, 
+          the {+bi-short+} attempts to connect using Unix socket.
 
       * - **PORT**
         - The :abbr:`IANA (Internet Assigned Numbers Authority)`

--- a/source/includes/steps-create-system-dsn-auth-ssl-macos.rst
+++ b/source/includes/steps-create-system-dsn-auth-ssl-macos.rst
@@ -43,11 +43,9 @@ a. Launch ODBC Manager.
       * - **SERVER**
         - The hostname or IP address of the |bi| host.
 
-          .. important::
-
-             Use ``127.0.0.1`` to connect via TCP to localhost.
-             Specifying a value other than an IP address, will attempt to
-             connect via Unix socket.
+          :gold:`IMPORTANT:` Use ``127.0.0.1`` to connect using TCP to
+          localhost. If you specify a value other than an IP address, 
+          the {+bi-short+} attempts to connect using Unix socket.
 
       * - **PORT**
         - The :abbr:`IANA (Internet Assigned Numbers Authority)`

--- a/source/includes/steps-create-system-dsn-macos.rst
+++ b/source/includes/steps-create-system-dsn-macos.rst
@@ -43,11 +43,9 @@
       * - **SERVER**
         - The hostname or IP address of the |bi| host.
 
-          .. important::
-
-             Use ``127.0.0.1`` to connect via TCP to localhost.
-             Specifying a value other than an IP address, will attempt to
-             connect via Unix socket.
+          :gold:`IMPORTANT:` Use ``127.0.0.1`` to connect using TCP to
+          localhost. If you specify a value other than an IP address, 
+          the {+bi-short+} attempts to connect using Unix socket.
 
       * - **PORT**
         - The :abbr:`IANA (Internet Assigned Numbers Authority)`

--- a/source/includes/steps-create-system-dsn-no-auth-macos.rst
+++ b/source/includes/steps-create-system-dsn-no-auth-macos.rst
@@ -43,11 +43,9 @@ a. Launch ODBC Manager.
       * - **SERVER**
         - The hostname or IP address of the |bi| host.
 
-          .. important::
-
-             Use ``127.0.0.1`` to connect via TCP to localhost.
-             Specifying a value other than an IP address, will attempt to
-             connect via Unix socket.
+          :gold:`IMPORTANT:` Use ``127.0.0.1`` to connect using TCP to
+          localhost. If you specify a value other than an IP address, 
+          the {+bi-short+} attempts to connect using Unix socket.
 
       * - **PORT**
         - The :abbr:`IANA (Internet Assigned Numbers Authority)`

--- a/source/includes/steps-install-bi-connector-debian.yaml
+++ b/source/includes/steps-install-bi-connector-debian.yaml
@@ -12,7 +12,7 @@ level: 4
 content: |
   The MongoDB release team digitally signs all software packages to
   certify that a particular MongoDB package is a valid and unaltered
-  MongoDB release. The `bi-connector.asc` key to validate the BI
+  MongoDB release. The ``bi-connector.asc`` key to validate the BI
   Connector is available on `pgp.mongodb.com <https://pgp.mongodb.com/bi-connector.asc>`__
   as a PGP key in ``.asc`` format.  
 

--- a/source/includes/steps-install-bi-connector-macos.yaml
+++ b/source/includes/steps-install-bi-connector-macos.yaml
@@ -12,7 +12,7 @@ level: 4
 content: |
   The MongoDB release team digitally signs all software packages to
   certify that a particular MongoDB package is a valid and unaltered
-  MongoDB release. The `bi-connector.asc` key to validate the BI
+  MongoDB release. The ``bi-connector.asc`` key to validate the BI
   Connector is available on `pgp.mongodb.com <https://pgp.mongodb.com/bi-connector.asc>`__ 
   as a PGP key in ``.asc`` format.  
 

--- a/source/includes/steps-install-bi-connector-rhel.yaml
+++ b/source/includes/steps-install-bi-connector-rhel.yaml
@@ -12,7 +12,7 @@ level: 4
 content: |
   The MongoDB release team digitally signs all software packages to
   certify that a particular MongoDB package is a valid and unaltered
-  MongoDB release. The `bi-connector.asc` key to validate the BI
+  MongoDB release. The ``bi-connector.asc`` key to validate the BI
   Connector is available on `pgp.mongodb.com
   <https://pgp.mongodb.com/bi-connector.asc>`__ as a PGP key in ``.asc`` format.  
 

--- a/source/schema/cached-sampling.txt
+++ b/source/schema/cached-sampling.txt
@@ -44,7 +44,7 @@ If your MongoDB instance uses :manual:`authentication
 </core/authentication/>` and you wish to use cached sampling, your
 |bi-short| instance must also use authentication. The admin user that
 connects to MongoDB via the :binary:`~bin.mongosqld` program must
-have permission to read from all the :term:`namespaces <namespace>`
+have permission to read from all the :manual:`namespaces </reference/glossary/#std-term-namespace>`
 from which you want to sample data.
 
 Sample All Namespaces


### PR DESCRIPTION
Also fixes some preexisting build errors due to monospace backticks missing and an ambiguous reference. Remaining 2 preexisting errors need investigation and are outside the scope of this ticket.

[DOCSP](https://jira.mongodb.org/browse/DOCSP-44175)
Staging Links:
https://deploy-preview-447--mongodb-docs-bi-connector.netlify.app/connect/tableau-auth
https://deploy-preview-447--mongodb-docs-bi-connector.netlify.app/connect/tableau-auth-ssl
https://deploy-preview-447--mongodb-docs-bi-connector.netlify.app/connect/tableau-no-auth
https://deploy-preview-447--mongodb-docs-bi-connector.netlify.app/tutorial/create-system-dsn