### PR TITLE
(DOCSP-47223) [BIC] Update outdated link on BI Connector documentation

### DIFF
--- a/source/connect/mysql.txt
+++ b/source/connect/mysql.txt
@@ -212,7 +212,7 @@ For additional options, see the
 :ref:`MySQL Commands <mysql-command-options>`.
 
 See the
-`MySQL documentation <https://dev.mysql.com/doc/refman/5.7/en/cleartext-authentication-plugin.html>`_
+`MySQL documentation <https://dev.mysql.com/doc/mysql-security-excerpt/en/cleartext-pluggable-authentication.html>`_
 for additional details on enabling the MySQL cleartext plugin.
 
 .. toctree::


### PR DESCRIPTION
MySQL updated its documentation and moved a couple of pages.
Update the link behind "MySQL documentation" from "https://dev.mysql.com/doc/refman/5.7/en/cleartext-authentication-plugin.html" to "https://dev.mysql.com/doc/mysql-security-excerpt/en/cleartext-pluggable-authentication.html"

The section is at the bottom of the page.

> See the [MySQL documentation](https://dev.mysql.com/doc/refman/5.7/en/cleartext-authentication-plugin.html) for additional details on enabling the MySQL cleartext plugin.

- [DOCSP-47223](https://jira.mongodb.org/browse/DOCSP-47223)
- [STAGING](https://deploy-preview-454--docs-bi-connector.netlify.app/connect/mysql/)